### PR TITLE
Constant local promotion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 osx_image: xcode10
 language: objective-c
 script:
-  - swift build
   - swift test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 osx_image: xcode10
 language: objective-c
 script:
-  - swift test
+  - swift test --parallel

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+osx_image: xcode10
+language: objective-c
+script:
+  - swift build
+  - swift test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SwiftRewriter
 
+[![CI Status](https://api.travis-ci.org/LuizZak/SwiftRewriter.svg?branch=swift4.2)](https://travis-ci.org/LuizZak/SwiftRewriter?branch=swift4.2)
+
 A program that aims to aid in automatization of conversion of Objective-C code into equivalent Swift code.
 
 #### Requirements

--- a/Sources/Commons/PostfixTransformation.swift
+++ b/Sources/Commons/PostfixTransformation.swift
@@ -6,7 +6,11 @@ import SwiftAST
 public enum PostfixTransformation {
     case method(MethodInvocationTransformerMatcher)
     case property(old: String, new: String)
-    case propertyFromMethods(property: String, getterName: String, setterName: String?)
+    case propertyFromMethods(property: String,
+                             getterName: String,
+                             setterName: String?,
+                             resultType: SwiftType,
+                             isStatic: Bool)
     case initializer(old: [ParameterSignature], new: [ParameterSignature])
     case valueTransformer(ValueTransformer<PostfixExpression, Expression>)
 }

--- a/Sources/Commons/UIViewCompoundType.swift
+++ b/Sources/Commons/UIViewCompoundType.swift
@@ -1108,11 +1108,18 @@ class TransformationsSink {
         mappings.append(matcher)
     }
     
-    func addPropertyFromMethods(property: String, getter: String, setter: String?) {
+    func addPropertyFromMethods(property: String,
+                                getter: String,
+                                setter: String?,
+                                propertyType: SwiftType,
+                                isStatic: Bool) {
+        
         postfixTransformations.append(
             .propertyFromMethods(property: property,
                                  getterName: getter,
-                                 setterName: setter)
+                                 setterName: setter,
+                                 resultType: propertyType,
+                                 isStatic: isStatic)
         )
     }
     

--- a/Sources/ExpressionPasses/ConstantDetectionExpressionPass.swift
+++ b/Sources/ExpressionPasses/ConstantDetectionExpressionPass.swift
@@ -1,0 +1,30 @@
+import SwiftAST
+import SwiftRewriterLib
+
+/// Allows detecting local variables that are never mutated and can be marked as
+/// constant `let` declarations.
+public class ConstantDetectionExpressionPass: ASTRewriterPass {
+    
+    public override func visitVariableDeclarations(_ stmt: VariableDeclarationsStatement) -> Statement {
+        guard let functionBody = context.functionBodyIntention else {
+            return super.visitVariableDeclarations(stmt)
+        }
+        
+        let usage = LocalUsageAnalyzer(functionBody: functionBody)
+        for (i, decl) in stmt.decl.enumerated() where !decl.isConstant {
+            let usages = usage.findUsagesOf(localNamed: decl.identifier)
+            
+            // Look for read-only usages
+            if usages.contains(where: { !$0.isReadOnlyUsage }) {
+                return super.visitVariableDeclarations(stmt)
+            }
+            
+            stmt.decl[i].isConstant = true
+        }
+        
+        notifyChange()
+        
+        return stmt
+    }
+    
+}

--- a/Sources/ExpressionPasses/ConstantDetectionExpressionPass.swift
+++ b/Sources/ExpressionPasses/ConstantDetectionExpressionPass.swift
@@ -10,7 +10,9 @@ public class ConstantDetectionExpressionPass: ASTRewriterPass {
             return super.visitVariableDeclarations(stmt)
         }
         
-        let usage = LocalUsageAnalyzer(functionBody: functionBody)
+        let usage = LocalUsageAnalyzer(functionBody: functionBody,
+                                       typeSystem: context.typeSystem)
+        
         for (i, decl) in stmt.decl.enumerated() where !decl.isConstant {
             let usages = usage.findUsagesOf(localNamed: decl.identifier)
             

--- a/Sources/ExpressionPasses/DefaultExpressionPasses.swift
+++ b/Sources/ExpressionPasses/DefaultExpressionPasses.swift
@@ -14,7 +14,7 @@ public class DefaultExpressionPasses: ASTRewriterPassSource {
         ASTCorrectorExpressionPass.self,
         NumberCommonsExpressionPass.self,
         EnumRewriterExpressionPass.self,
-        ConstantDetectionExpressionPass.self,
+        LocalConstantPromotionExpressionPass.self,
         // Do a last simplification pass after all other passes
         ASTSimplifier.self
     ]

--- a/Sources/ExpressionPasses/DefaultExpressionPasses.swift
+++ b/Sources/ExpressionPasses/DefaultExpressionPasses.swift
@@ -14,6 +14,7 @@ public class DefaultExpressionPasses: ASTRewriterPassSource {
         ASTCorrectorExpressionPass.self,
         NumberCommonsExpressionPass.self,
         EnumRewriterExpressionPass.self,
+        ConstantDetectionExpressionPass.self,
         // Do a last simplification pass after all other passes
         ASTSimplifier.self
     ]

--- a/Sources/ExpressionPasses/LocalConstantPromotionExpressionPass.swift
+++ b/Sources/ExpressionPasses/LocalConstantPromotionExpressionPass.swift
@@ -3,7 +3,7 @@ import SwiftRewriterLib
 
 /// Allows detecting local variables that are never mutated and can be marked as
 /// constant `let` declarations.
-public class ConstantDetectionExpressionPass: ASTRewriterPass {
+public class LocalConstantPromotionExpressionPass: ASTRewriterPass {
     
     public override func visitVariableDeclarations(_ stmt: VariableDeclarationsStatement) -> Statement {
         guard let functionBody = context.functionBodyIntention else {

--- a/Sources/ExpressionPasses/MethodsToPropertyTransformer.swift
+++ b/Sources/ExpressionPasses/MethodsToPropertyTransformer.swift
@@ -8,16 +8,19 @@ public final class MethodsToPropertyTransformer: PostfixInvocationTransformer {
     let getterName: String
     let setterName: String?
     let propertyName: String
+    let resultType: SwiftType
     
     init(baseExpressionMatcher: ValueMatcher<Expression>,
          getterName: String,
          setterName: String?,
-         propertyName: String) {
+         propertyName: String,
+         resultType: SwiftType) {
         
         self.baseExpressionMatcher = baseExpressionMatcher
         self.getterName = getterName
         self.setterName = setterName
         self.propertyName = propertyName
+        self.resultType = resultType
     }
     
     func canApply(to postfix: PostfixExpression) -> Bool {
@@ -71,7 +74,7 @@ public final class MethodsToPropertyTransformer: PostfixInvocationTransformer {
         }
         
         if functionCall.arguments.isEmpty {
-            return memberNameAccess.exp.copy().dot(propertyName)
+            return memberNameAccess.exp.copy().dot(propertyName).typed(resultType)
         } else if functionCall.arguments.count == 1 && setterName != nil {
             return
                 memberNameAccess

--- a/Sources/ExpressionPasses/UIKitExpressionPass.swift
+++ b/Sources/ExpressionPasses/UIKitExpressionPass.swift
@@ -109,6 +109,8 @@ public class UIKitExpressionPass: BaseExpressionPass {
     
     /// Converts UIColor.orangeColor() -> UIColor.orange, etc.
     func convertUIColorStaticColorMethodCall(_ exp: PostfixExpression) -> Expression? {
+        return nil
+        /*
         guard let args = exp.functionCall?.arguments, args.isEmpty else {
             return nil
         }
@@ -124,6 +126,7 @@ public class UIKitExpressionPass: BaseExpressionPass {
         exp.op = .member(String(colorName.dropLast("Color".count)))
         
         return exp
+        */
     }
     
     /// Converts [<exp> addTarget:<a1> action:<a2> forControlEvents:<a3>]

--- a/Sources/SwiftAST/AnonymousSyntaxNodeVisitor.swift
+++ b/Sources/SwiftAST/AnonymousSyntaxNodeVisitor.swift
@@ -14,8 +14,6 @@ public final class AnonymousSyntaxNodeVisitor: ExpressionVisitor, StatementVisit
     ///
     /// - Parameter exp: An Expression to visit
     public func visitExpression(_ exp: Expression) {
-        listener(exp)
-        
         exp.accept(self)
     }
     
@@ -191,9 +189,7 @@ public final class AnonymousSyntaxNodeVisitor: ExpressionVisitor, StatementVisit
     ///
     /// - Parameter stmt: A Statement to visit
     public func visitStatement(_ stmt: Statement) {
-        listener(stmt)
-        
-        return stmt.accept(self)
+        stmt.accept(self)
     }
     
     /// Visits a semicolon node

--- a/Sources/SwiftAST/Expression.swift
+++ b/Sources/SwiftAST/Expression.swift
@@ -498,6 +498,30 @@ public class PostfixExpression: Expression {
         return "\(exp)\(op)"
     }
     
+    /// Returns the first ancestor of this postfix which is not a postfix node
+    /// itself.
+    public var firstNonPostfixAncestor: SyntaxNode? {
+        if let postfix = parent as? PostfixExpression {
+            return postfix.firstNonPostfixAncestor
+        }
+        
+        return parent
+    }
+    
+    /// In case this postfix expression is contained within another postfix
+    /// expression, returns the parent postfix's top postfix, until the top-most
+    /// postfix entry is found.
+    ///
+    /// This can be useful to traverse from an inner postfix access until the
+    /// outermost access, wherein a postfix access chain finishes.
+    public var topPostfixExpression: PostfixExpression {
+        if let postfix = parent as? PostfixExpression {
+            return postfix.topPostfixExpression
+        }
+        
+        return self
+    }
+    
     public init(exp: Expression, op: Postfix) {
         self.exp = exp
         self.op = op

--- a/Sources/SwiftAST/SyntaxNode.swift
+++ b/Sources/SwiftAST/SyntaxNode.swift
@@ -21,4 +21,40 @@ open class SyntaxNode {
     open func copy() -> SyntaxNode {
         fatalError("Must be overriden by subclasses")
     }
+    
+    /// Returns `true` if this syntax node is either the same as a given syntax
+    /// node, or a descendent of it.
+    public func isDescendent(of other: SyntaxNode) -> Bool {
+        if other === self {
+            return true
+        }
+        
+        var currentParent = parent
+        while let p = currentParent {
+            if p === other {
+                return true
+            }
+            
+            currentParent = p.parent
+        }
+        
+        return false
+    }
+    
+    /// Returns the first ancestor of this node which matches a given node type,
+    /// excluding itself.
+    ///
+    /// Returns `nil`, in case no ancestor of the given type is found.
+    public func firstAncestor<T: SyntaxNode>(ofType type: T.Type = T.self) -> T? {
+        var currentParent = parent
+        while let p = currentParent {
+            if let ancestor = p as? T {
+                return ancestor
+            }
+            
+            currentParent = p.parent
+        }
+        
+        return nil
+    }
 }

--- a/Sources/SwiftRewriterLib/ASTRewriterPass.swift
+++ b/Sources/SwiftRewriterLib/ASTRewriterPass.swift
@@ -8,6 +8,7 @@ public struct ASTRewriterPassContext {
     public let typeSystem: TypeSystem
     public let typeResolver: ExpressionTypeResolver
     public let source: FunctionBodyCarryingIntention?
+    public let functionBodyIntention: FunctionBodyIntention?
     
     /// Must be called by every `ASTRewriterPass` if it makes any sort of change
     /// to a syntax tree.
@@ -18,23 +19,27 @@ public struct ASTRewriterPassContext {
     
     public init(typeSystem: TypeSystem,
                 notifyChangedTree: @escaping () -> Void = { },
-                source: FunctionBodyCarryingIntention? = nil) {
+                source: FunctionBodyCarryingIntention? = nil,
+                functionBodyIntention: FunctionBodyIntention? = nil) {
         
         self.typeSystem = typeSystem
         self.typeResolver = ExpressionTypeResolver(typeSystem: typeSystem)
         self.notifyChangedTree = notifyChangedTree
         self.source = source
+        self.functionBodyIntention = functionBodyIntention
     }
     
     public init(typeSystem: TypeSystem,
                 typeResolver: ExpressionTypeResolver,
                 notifyChangedTree: @escaping () -> Void = { },
-                source: FunctionBodyCarryingIntention? = nil) {
+                source: FunctionBodyCarryingIntention? = nil,
+                functionBodyIntention: FunctionBodyIntention? = nil) {
         
         self.typeSystem = typeSystem
         self.typeResolver = typeResolver
         self.notifyChangedTree = notifyChangedTree
         self.source = source
+        self.functionBodyIntention = functionBodyIntention
     }
 }
 

--- a/Sources/SwiftRewriterLib/ASTRewriterPassApplier.swift
+++ b/Sources/SwiftRewriterLib/ASTRewriterPassApplier.swift
@@ -51,7 +51,8 @@ public final class ASTRewriterPassApplier {
             ASTRewriterPassContext(typeSystem: self.typeSystem,
                                    typeResolver: item.context.typeResolver,
                                    notifyChangedTree: notifyChangedTree,
-                                   source: item.intention)
+                                   source: item.intention,
+                                   functionBodyIntention: item.body)
         
         let pass = passType.init(context: expContext)
         _=pass.apply(on: item.body.body, context: expContext)

--- a/Sources/SwiftRewriterLib/DefaultTypeSystem.swift
+++ b/Sources/SwiftRewriterLib/DefaultTypeSystem.swift
@@ -1098,7 +1098,8 @@ extension DefaultTypeSystem {
                                                         name: "selector",
                                                         type: .selector)],
                         returnType: .bool,
-                        isStatic: false)
+                        isStatic: false,
+                        isMutating: false)
                 )
                 .method(withSignature:
                     FunctionSignature(
@@ -1107,7 +1108,8 @@ extension DefaultTypeSystem {
                                                         name: "object",
                                                         type: .anyObject)],
                         returnType: .bool,
-                        isStatic: false)
+                        isStatic: false,
+                        isMutating: false)
                 )
                 .build()
         
@@ -1132,7 +1134,8 @@ extension DefaultTypeSystem {
                             ParameterSignature(label: "forKey", name: "aKey", type: .anyObject)
                         ],
                         returnType: .void,
-                        isStatic: false
+                        isStatic: false,
+                        isMutating: false
                     ),
                         semantics: Semantics.collectionMutator
                 )
@@ -1149,7 +1152,8 @@ extension DefaultTypeSystem {
                         name: "add",
                         parameters: [
                             ParameterSignature(label: nil, name: "object", type: .anyObject)
-                        ]
+                        ],
+                        isMutating: false
                     ),
                         semantics: Semantics.collectionMutator
                 )
@@ -1303,10 +1307,8 @@ func _applyOverloadResolution(signatures: [FunctionSignature],
                 let parameterType =
                     signature.element.parameters[argIndex].type
                 
-                // TODO: Support sub-type matching as well here
-                if !typeSystem.typesMatch(argumentType,
-                                          parameterType,
-                                          ignoreNullability: true) {
+                if !typeSystem.isType(argumentType.deepUnwrapped,
+                                      assignableTo: parameterType.deepUnwrapped) {
                     
                     candidates.remove(at: i)
                     doWork = true

--- a/Sources/SwiftRewriterLib/FunctionBodyQueue.swift
+++ b/Sources/SwiftRewriterLib/FunctionBodyQueue.swift
@@ -211,3 +211,27 @@ public enum FunctionBodyCarryingIntention {
     case global(GlobalFunctionGenerationIntention)
     case property(PropertyGenerationIntention, isSetter: Bool)
 }
+
+/// An empty funtion body queue implementation which always return an empty
+/// context object.
+public class EmptyFunctionBodyQueueDelegate: FunctionBodyQueueDelegate {
+    public typealias Context = Void
+    
+    public func makeContext(forFunction function: GlobalFunctionGenerationIntention) {
+        
+    }
+    public func makeContext(forMethod method: MethodGenerationIntention) {
+        
+    }
+    public func makeContext(forInit ctor: InitGenerationIntention) {
+        
+    }
+    public func makeContext(forPropertyGetter property: PropertyGenerationIntention,
+                            getter: FunctionBodyIntention) {
+        
+    }
+    public func makeContext(forPropertySetter property: PropertyGenerationIntention,
+                            setter: PropertyGenerationIntention.Setter) {
+        
+    }
+}

--- a/Sources/SwiftRewriterLib/Intentions/GlobalFunctionGenerationIntention.swift
+++ b/Sources/SwiftRewriterLib/Intentions/GlobalFunctionGenerationIntention.swift
@@ -27,7 +27,10 @@ public class GlobalFunctionGenerationIntention: FromSourceIntention, FileLevelIn
     
     public var functionBody: FunctionBodyIntention?
     
-    public init(signature: FunctionSignature, accessLevel: AccessLevel = .internal, source: ASTNode? = nil) {
+    public init(signature: FunctionSignature,
+                accessLevel: AccessLevel = .internal,
+                source: ASTNode? = nil) {
+        
         self.signature = signature
         super.init(accessLevel: accessLevel, source: source)
     }

--- a/Sources/SwiftRewriterLib/Intentions/MethodGenerationIntention.swift
+++ b/Sources/SwiftRewriterLib/Intentions/MethodGenerationIntention.swift
@@ -48,7 +48,8 @@ public class MethodGenerationIntention: MemberGenerationIntention, OverridableMe
             FunctionSignature(name: name,
                               parameters: parameters,
                               returnType: returnType,
-                              isStatic: isStatic)
+                              isStatic: isStatic,
+                              isMutating: false)
         
         self.init(signature: signature,
                   accessLevel: accessLevel,

--- a/Sources/SwiftRewriterLib/KnownTypeBuilder.swift
+++ b/Sources/SwiftRewriterLib/KnownTypeBuilder.swift
@@ -172,6 +172,7 @@ public struct KnownTypeBuilder {
                        shortParams: [ParameterTuple] = [],
                        returning returnType: SwiftType = .void,
                        isStatic: Bool = false,
+                       isMutating: Bool = false,
                        optional: Bool = false,
                        semantics: Set<Semantic> = [],
                        annotations: [String] = []) -> KnownTypeBuilder {
@@ -184,7 +185,8 @@ public struct KnownTypeBuilder {
         let signature = FunctionSignature(name: name,
                                           parameters: parameters,
                                           returnType: returnType,
-                                          isStatic: isStatic)
+                                          isStatic: isStatic,
+                                          isMutating: isMutating)
         
         return method(withSignature: signature,
                       optional: optional,
@@ -236,6 +238,7 @@ public struct KnownTypeBuilder {
     public func method(named name: String,
                        parsingSignature signature: String,
                        isStatic: Bool = false,
+                       isMutating: Bool = false,
                        returning returnType: SwiftType = .void,
                        optional: Bool = false,
                        semantics: Set<Semantic> = [],
@@ -247,7 +250,8 @@ public struct KnownTypeBuilder {
             FunctionSignature(name: name,
                               parameters: params,
                               returnType: returnType,
-                              isStatic: isStatic)
+                              isStatic: isStatic,
+                              isMutating: isMutating)
         
         return method(withSignature: signature,
                       optional: optional,

--- a/Sources/SwiftRewriterLib/Structures/FunctionSignature.swift
+++ b/Sources/SwiftRewriterLib/Structures/FunctionSignature.swift
@@ -2,6 +2,7 @@ import SwiftAST
 
 /// Signature for a function intention
 public struct FunctionSignature: Equatable, Codable {
+    public var isMutating: Bool
     public var isStatic: Bool
     public var name: String
     public var returnType: SwiftType
@@ -32,18 +33,21 @@ public struct FunctionSignature: Equatable, Codable {
         return FunctionSignature(name: name,
                                  parameters: parameters,
                                  returnType: returnType.deepUnwrapped,
-                                 isStatic: isStatic)
+                                 isStatic: isStatic,
+                                 isMutating: isMutating)
     }
     
     public init(name: String,
                 parameters: [ParameterSignature] = [],
                 returnType: SwiftType = .void,
-                isStatic: Bool = false) {
+                isStatic: Bool = false,
+                isMutating: Bool = false) {
         
         self.isStatic = isStatic
         self.name = name
         self.returnType = returnType
         self.parameters = parameters
+        self.isMutating = isMutating
     }
     
     /// Returns `true` iff `self` and `other` match using Swift signature matching

--- a/Sources/SwiftRewriterLib/SwiftMethodSignatureGen.swift
+++ b/Sources/SwiftRewriterLib/SwiftMethodSignatureGen.swift
@@ -21,7 +21,8 @@ public class SwiftMethodSignatureGen {
             FunctionSignature(name: "__",
                               parameters: [],
                               returnType: SwiftType.anyObject.asImplicitUnwrapped,
-                              isStatic: objcMethod.isClassMethod)
+                              isStatic: objcMethod.isClassMethod,
+                              isMutating: false)
         
         if let sel = objcMethod.methodSelector?.selector {
             switch sel {
@@ -59,7 +60,8 @@ public class SwiftMethodSignatureGen {
             FunctionSignature(name: function.identifier?.name ?? "__",
                               parameters: [],
                               returnType: .void,
-                              isStatic: false)
+                              isStatic: false,
+                              isMutating: false)
         
         var context = TypeMappingContext.empty
         context.instanceTypeAlias = instanceTypeAlias

--- a/Sources/SwiftRewriterLib/UsageAnalysis.swift
+++ b/Sources/SwiftRewriterLib/UsageAnalysis.swift
@@ -3,32 +3,26 @@ import SwiftAST
 /// Simplified API interface to find usages of symbols across intentions
 public protocol UsageAnalyzer {
     /// Finds all usages of a known method
-    func findUsagesOf(method: KnownMethod) -> [MemberUsage]
+    func findUsagesOf(method: KnownMethod) -> [DefinitionUsage]
     
     /// Finds all usages of a known property
-    func findUsagesOf(property: KnownProperty) -> [MemberUsage]
+    func findUsagesOf(property: KnownProperty) -> [DefinitionUsage]
 }
 
-/// Default implementation of UsageAnalyzer
-public class DefaultUsageAnalyzer: UsageAnalyzer {
-    public var intentions: IntentionCollection
-    
-    public init(intentions: IntentionCollection) {
-        self.intentions = intentions
-    }
-    
-    public func findUsagesOf(method: KnownMethod) -> [MemberUsage] {
-        let types = intentions.typeIntentions()
+/// A refined usage analyzer capable of inspecting usages of local variables by
+/// name within a method body.
+public protocol LocalsUsageAnalyzer: UsageAnalyzer {
+    func findUsagesOf(local: String) -> [DefinitionUsage]
+}
+
+public class BaseUsageAnalyzer: UsageAnalyzer {
+    public func findUsagesOf(method: KnownMethod) -> [DefinitionUsage] {
+        let bodies = functionBodies()
         
-        // Get all existing method bodies, from all types
-        let typeMethods = types.flatMap { $0.methods }
+        var usages: [DefinitionUsage] = []
         
-        var usages: [MemberUsage] = []
-        
-        for typeMethod in typeMethods {
-            guard let body = typeMethod.functionBody?.body else {
-                continue
-            }
+        for functionBody in bodies {
+            let body = functionBody.body
             
             let iterator = SyntaxNodeSequence(node: body, inspectBlocks: true)
             
@@ -41,7 +35,9 @@ public class DefaultUsageAnalyzer: UsageAnalyzer {
                 }
                 
                 if expMethod.ownerType?.asTypeName == method.ownerType?.asTypeName {
-                    let usage = MemberUsage(function: typeMethod, expression: exp)
+                    let usage = DefinitionUsage(intention: functionBody,
+                                                expression: exp,
+                                                isReadOnlyUsage: true)
                     
                     usages.append(usage)
                 }
@@ -51,18 +47,13 @@ public class DefaultUsageAnalyzer: UsageAnalyzer {
         return usages
     }
     
-    public func findUsagesOf(property: KnownProperty) -> [MemberUsage] {
-        let types = intentions.typeIntentions()
+    public func findUsagesOf(property: KnownProperty) -> [DefinitionUsage] {
+        let bodies = functionBodies()
         
-        // Get all existing method bodies, from all types
-        let typeMethods = types.flatMap { $0.methods }
+        var usages: [DefinitionUsage] = []
         
-        var usages: [MemberUsage] = []
-        
-        for typeMethod in typeMethods {
-            guard let body = typeMethod.functionBody?.body else {
-                continue
-            }
+        for functionBody in bodies {
+            let body = functionBody.body
             
             let iterator = SyntaxNodeSequence(node: body, inspectBlocks: true)
             
@@ -75,7 +66,11 @@ public class DefaultUsageAnalyzer: UsageAnalyzer {
                 }
                 
                 if expProperty.ownerType?.asTypeName == property.ownerType?.asTypeName {
-                    let usage = MemberUsage(function: typeMethod, expression: exp)
+                    let readOnly = isReadOnlyContext(exp)
+                    
+                    let usage = DefinitionUsage(intention: functionBody,
+                                                expression: exp,
+                                                isReadOnlyUsage: readOnly)
                     
                     usages.append(usage)
                 }
@@ -84,16 +79,114 @@ public class DefaultUsageAnalyzer: UsageAnalyzer {
         
         return usages
     }
+    
+    func isReadOnlyContext(_ expression: Expression) -> Bool {
+        if let assignment = expression.parentExpression?.asAssignment {
+            return expression !== assignment.lhs
+        }
+        // Unary '&' is interpreted as 'address-of', which is a mutable operation.
+        if let unary = expression.parentExpression?.asUnary {
+            return unary.op != .bitwiseAnd
+        }
+        if let postfix = expression.parentExpression?.asPostfix {
+            let root = postfix.topPostfixExpression
+            
+            let chain = PostfixChainInverter.invert(expression: root)
+            if chain.contains(where: { $0.postfix is FunctionCallPostfix }) {
+                return true
+            }
+            
+            return isReadOnlyContext(root)
+        }
+        
+        return true
+    }
+    
+    func functionBodies() -> [FunctionBodyIntention] {
+        return []
+    }
+}
+
+/// Default implementation of UsageAnalyzer which searches for definitions in all
+/// method bodies.
+public class DefaultUsageAnalyzer: BaseUsageAnalyzer {
+    public var intentions: IntentionCollection
+    
+    public init(intentions: IntentionCollection) {
+        self.intentions = intentions
+    }
+    
+    override func functionBodies() -> [FunctionBodyIntention] {
+        let queue =
+            FunctionBodyQueue.fromIntentionCollection(
+                intentions, delegate: EmptyFunctionBodyQueueDelegate())
+        
+        return queue.items.map { $0.body }
+    }
+}
+
+public class LocalUsageAnalyzer: BaseUsageAnalyzer {
+    public var functionBody: FunctionBodyIntention
+    
+    public init(functionBody: FunctionBodyIntention) {
+        self.functionBody = functionBody
+    }
+    
+    public func findUsagesOf(localNamed local: String) -> [DefinitionUsage] {
+        let bodies = functionBodies()
+        
+        var usages: [DefinitionUsage] = []
+        
+        for functionBody in bodies {
+            let body = functionBody.body
+            
+            let visitor =
+                AnonymousSyntaxNodeVisitor { node in
+                    guard let identifier = node as? IdentifierExpression else {
+                        return
+                    }
+                    
+                    switch identifier.definition {
+                    case .local(let definition)? where definition.name == local:
+                        let readOnly = self.isReadOnlyContext(identifier)
+                        
+                        let usage = DefinitionUsage(intention: functionBody,
+                                                    expression: identifier,
+                                                    isReadOnlyUsage: readOnly)
+                        
+                        usages.append(usage)
+                        
+                    default:
+                        break
+                    }
+                }
+            
+            visitor.visitStatement(body)
+        }
+        
+        return usages
+    }
+    
+    override func functionBodies() -> [FunctionBodyIntention] {
+        return [functionBody]
+    }
 }
 
 /// Reports the usage of a type member or global declaration
-public struct MemberUsage {
-    /// Function the usage is contained within
-    public var function: FunctionIntention
+public struct DefinitionUsage {
+    /// Intention for function body which this member usage is contained wihin.
+    public var intention: FunctionBodyIntention
     
     /// The expression the usage is effectively used.
     ///
-    /// This expression is a `PostfixExpression` where the `Postfix.member("")`
-    /// points to the actual member name.
-    public var expression: PostfixExpression
+    /// In case the usage is of a type member, this expression is a
+    /// `PostfixExpression` where the `Postfix.member("")` points to the actual
+    /// member name.
+    /// In case the usage is of a local variable, the expression points to the
+    /// identifier node referencing the variable.
+    public var expression: Expression
+    
+    /// Whether, in the context of this usage, the referenced definition is being
+    /// used in a read-only context.
+    public var isReadOnlyUsage: Bool
 }

--- a/Tests/CommonsTests/UIColorCompoundTypeTests.swift
+++ b/Tests/CommonsTests/UIColorCompoundTypeTests.swift
@@ -10,26 +10,99 @@ class UIColorCompoundTypeTests: XCTestCase {
         
         assertSignature(type: type, matches: """
             class UIColor: NSObject, NSSecureCoding, NSCopying {
+                // Convert from static var blackColor
+                // Convert from static func blackColor()
                 static var black: UIColor { get }
+                
+                // Convert from static var darkGrayColor
+                // Convert from static func darkGrayColor()
                 static var darkGray: UIColor { get }
+                
+                // Convert from static var lightGrayColor
+                // Convert from static func lightGrayColor()
                 static var lightGray: UIColor { get }
+                
+                // Convert from static var whiteColor
+                // Convert from static func whiteColor()
                 static var white: UIColor { get }
+                
+                // Convert from static var grayColor
+                // Convert from static func grayColor()
                 static var gray: UIColor { get }
+                
+                // Convert from static var redColor
+                // Convert from static func redColor()
                 static var red: UIColor { get }
+                
+                // Convert from static var greenColor
+                // Convert from static func greenColor()
                 static var green: UIColor { get }
+                
+                // Convert from static var blueColor
+                // Convert from static func blueColor()
                 static var blue: UIColor { get }
+                
+                // Convert from static var cyanColor
+                // Convert from static func cyanColor()
                 static var cyan: UIColor { get }
+                
+                // Convert from static var yellowColor
+                // Convert from static func yellowColor()
                 static var yellow: UIColor { get }
+                
+                // Convert from static var magentaColor
+                // Convert from static func magentaColor()
                 static var magenta: UIColor { get }
+                
+                // Convert from static var orangeColor
+                // Convert from static func orangeColor()
                 static var orange: UIColor { get }
+                
+                // Convert from static var purpleColor
+                // Convert from static func purpleColor()
                 static var purple: UIColor { get }
+                
+                // Convert from static var brownColor
+                // Convert from static func brownColor()
                 static var brown: UIColor { get }
+                
+                // Convert from static var clearColor
+                // Convert from static func clearColor()
                 static var clear: UIColor { get }
-                // Convert from 'CGColor'
+                
+                // Convert from static var lightTextColor
+                // Convert from static func lightTextColor()
+                static var lightText: UIColor { get }
+                
+                // Convert from static var darkTextColor
+                // Convert from static func darkTextColor()
+                static var darkText: UIColor { get }
+                
+                // Convert from static var groupTableViewBackgroundColor
+                // Convert from static func groupTableViewBackgroundColor()
+                static var groupTableViewBackground: UIColor { get }
+                
+                // Convert from static var viewFlipsideBackgroundColor
+                // Convert from static func viewFlipsideBackgroundColor()
+                static var viewFlipsideBackground: UIColor { get }
+                
+                // Convert from static var scrollViewTexturedBackgroundColor
+                // Convert from static func scrollViewTexturedBackgroundColor()
+                static var scrollViewTexturedBackground: UIColor { get }
+                
+                // Convert from static var underPageBackgroundColor
+                // Convert from static func underPageBackgroundColor()
+                static var underPageBackground: UIColor { get }
+                
+                // Convert from var CGColor
                 var cgColor: CGColor { get }
                 
-                // Convert from 'CIColor'
+                // Convert from var CIColor
                 var ciColor: CGColor { get }
+                
+                
+                // Convert from colorWithAlphaComponent(_ alpha: CGFloat) -> UIColor
+                func withAlphaComponent(_ alpha: CGFloat) -> UIColor
             }
             """)
     }

--- a/Tests/CommonsTests/UIViewCompoundTypeTests.swift
+++ b/Tests/CommonsTests/UIViewCompoundTypeTests.swift
@@ -42,17 +42,17 @@ class UIViewCompoundTypeTests: XCTestCase {
                 var insetsLayoutMarginsFromSafeArea: Bool
                 var intrinsicContentSize: CGSize { get }
                 var isExclusiveTouch: Bool
-                // Convert from 'focused'
+                // Convert from var focused
                 var isFocused: Bool { get }
                 
-                // Convert from 'hidden'
+                // Convert from var hidden
                 var isHidden: Bool
                 var isMultipleTouchEnabled: Bool
                 
-                // Convert from 'opaque'
+                // Convert from var opaque
                 var isOpaque: Bool
                 
-                // Convert from 'userInteractionEnabled'
+                // Convert from var userInteractionEnabled
                 var isUserInteractionEnabled: Bool
                 var lastBaselineAnchor: NSLayoutYAxisAnchor { get }
                 var layer: CALayer { get }

--- a/Tests/ExpressionPassesTests/ASTCorrectorExpressionPassTests.swift
+++ b/Tests/ExpressionPassesTests/ASTCorrectorExpressionPassTests.swift
@@ -8,7 +8,7 @@ class ASTCorrectorExpressionPassTests: ExpressionPassTestCase {
     override func setUp() {
         super.setUp()
         
-        sut = ASTCorrectorExpressionPass(context: makeContext())
+        sutType = ASTCorrectorExpressionPass.self
     }
     
     /// Tests inserting null-coalesces on optional numeric types on the left

--- a/Tests/ExpressionPassesTests/ASTSimplifierTests.swift
+++ b/Tests/ExpressionPassesTests/ASTSimplifierTests.swift
@@ -8,7 +8,7 @@ class ASTSimplifierTests: ExpressionPassTestCase {
     override func setUp() {
         super.setUp()
         
-        sut = ASTSimplifier(context: makeContext())
+        sutType = ASTSimplifier.self
     }
     
     func testSimplifyDoWithinCompound() {

--- a/Tests/ExpressionPassesTests/AllocInitExpressionPassTests.swift
+++ b/Tests/ExpressionPassesTests/AllocInitExpressionPassTests.swift
@@ -7,7 +7,7 @@ class AllocInitExpressionPassTests: ExpressionPassTestCase {
     override func setUp() {
         super.setUp()
         
-        sut = AllocInitExpressionPass(context: makeContext())
+        sutType = AllocInitExpressionPass.self
     }
     
     func testPlainInit() {

--- a/Tests/ExpressionPassesTests/CanonicalNameExpressionPassTests.swift
+++ b/Tests/ExpressionPassesTests/CanonicalNameExpressionPassTests.swift
@@ -7,7 +7,7 @@ class CanonicalNameExpressionPassTests: ExpressionPassTestCase {
     override func setUp() {
         super.setUp()
         
-        sut = CanonicalNameExpressionPass(context: makeContext())
+        sutType = CanonicalNameExpressionPass.self
         
         let typeProvider = CollectionKnownTypeProvider()
         typeProvider.addCanonicalMapping(nonCanonical: "NonCanon",

--- a/Tests/ExpressionPassesTests/ConstantDetectionExpressionPassTests.swift
+++ b/Tests/ExpressionPassesTests/ConstantDetectionExpressionPassTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+import ExpressionPasses
+import SwiftRewriterLib
+import SwiftAST
+
+class ConstantDetectionExpressionPassTests: ExpressionPassTestCase {
+    override func setUp() {
+        super.setUp()
+        
+        sutType = ConstantDetectionExpressionPass.self
+        intentionContext = .global(
+            GlobalFunctionGenerationIntention(
+                signature: FunctionSignature(name: "test")
+            )
+        )
+    }
+    
+    func testDetectTrivialLetConstant() {
+        
+        let body: CompoundStatement = [
+            Statement.variableDeclaration(identifier: "test",
+                                          type: .int,
+                                          initialization: .constant(0))
+        ]
+        
+        functionBodyContext = FunctionBodyIntention(body: body)
+        
+        assertTransform(
+            statement: body,
+            into: CompoundStatement(statements: [
+                Statement.variableDeclaration(identifier: "test",
+                                              type: .int,
+                                              isConstant: true,
+                                              initialization: .constant(0))
+            ])
+        ); assertNotifiedChange()
+    }
+}

--- a/Tests/ExpressionPassesTests/CoreGraphicsExpressionPassTests.swift
+++ b/Tests/ExpressionPassesTests/CoreGraphicsExpressionPassTests.swift
@@ -7,7 +7,7 @@ class CoreGraphicsExpressionPassTests: ExpressionPassTestCase {
     override func setUp() {
         super.setUp()
         
-        sut = CoreGraphicsExpressionPass(context: makeContext())
+        sutType = CoreGraphicsExpressionPass.self
     }
     
     func testCGRectMake() {

--- a/Tests/ExpressionPassesTests/DefaultExpressionPassesTests.swift
+++ b/Tests/ExpressionPassesTests/DefaultExpressionPassesTests.swift
@@ -20,7 +20,7 @@ class DefaultExpressionPassesTests: XCTestCase {
         XCTAssert(passes.next() == ASTCorrectorExpressionPass.self)
         XCTAssert(passes.next() == NumberCommonsExpressionPass.self)
         XCTAssert(passes.next() == EnumRewriterExpressionPass.self)
-        XCTAssert(passes.next() == ConstantDetectionExpressionPass.self)
+        XCTAssert(passes.next() == LocalConstantPromotionExpressionPass.self)
         XCTAssert(passes.next() == ASTSimplifier.self)
     }
 }

--- a/Tests/ExpressionPassesTests/DefaultExpressionPassesTests.swift
+++ b/Tests/ExpressionPassesTests/DefaultExpressionPassesTests.swift
@@ -6,7 +6,7 @@ class DefaultExpressionPassesTests: XCTestCase {
         let source = DefaultExpressionPasses()
         var passes = source.syntaxNodePasses.makeIterator()
         
-        XCTAssertEqual(source.syntaxNodePasses.count, 13)
+        XCTAssertEqual(source.syntaxNodePasses.count, 14)
         
         XCTAssert(passes.next() == CanonicalNameExpressionPass.self)
         XCTAssert(passes.next() == AllocInitExpressionPass.self)
@@ -20,6 +20,7 @@ class DefaultExpressionPassesTests: XCTestCase {
         XCTAssert(passes.next() == ASTCorrectorExpressionPass.self)
         XCTAssert(passes.next() == NumberCommonsExpressionPass.self)
         XCTAssert(passes.next() == EnumRewriterExpressionPass.self)
+        XCTAssert(passes.next() == ConstantDetectionExpressionPass.self)
         XCTAssert(passes.next() == ASTSimplifier.self)
     }
 }

--- a/Tests/ExpressionPassesTests/EnumRewriterExpressionPassTests.swift
+++ b/Tests/ExpressionPassesTests/EnumRewriterExpressionPassTests.swift
@@ -8,7 +8,7 @@ class EnumRewriterExpressionPassTests: ExpressionPassTestCase {
     override func setUp() {
         super.setUp()
         
-        sut = EnumRewriterExpressionPass(context: makeContext())
+        sutType = EnumRewriterExpressionPass.self
     }
     
     func testReplaceEnum() {
@@ -35,6 +35,7 @@ class EnumRewriterExpressionPassTests: ExpressionPassTestCase {
                 .build()
         typeSystem.addType(en)
         
+        let sut = makeSut()
         let res = sut.apply(on: Expression.identifier("Enum_Case1").makeErrorTyped(), context: makeContext())
         
         XCTAssertEqual(

--- a/Tests/ExpressionPassesTests/FoundationExpressionPassTests.swift
+++ b/Tests/ExpressionPassesTests/FoundationExpressionPassTests.swift
@@ -7,7 +7,7 @@ class FoundationExpressionPassTests: ExpressionPassTestCase {
     override func setUp() {
         super.setUp()
         
-        sut = FoundationExpressionPass(context: makeContext())
+        sutType = FoundationExpressionPass.self
     }
     
     func testIsEqualToString() {

--- a/Tests/ExpressionPassesTests/InitRewriterExpressionPassTests.swift
+++ b/Tests/ExpressionPassesTests/InitRewriterExpressionPassTests.swift
@@ -8,7 +8,7 @@ class InitRewriterExpressionPassTests: ExpressionPassTestCase {
     override func setUp() {
         super.setUp()
         
-        sut = InitRewriterExpressionPass(context: makeContext())
+        sutType = InitRewriterExpressionPass.self
     }
     
     func testEmptyIfInInit() {

--- a/Tests/ExpressionPassesTests/LocalConstantPromotionExpressionPassTests.swift
+++ b/Tests/ExpressionPassesTests/LocalConstantPromotionExpressionPassTests.swift
@@ -3,11 +3,11 @@ import ExpressionPasses
 import SwiftRewriterLib
 import SwiftAST
 
-class ConstantDetectionExpressionPassTests: ExpressionPassTestCase {
+class LocalConstantPromotionExpressionPassTests: ExpressionPassTestCase {
     override func setUp() {
         super.setUp()
         
-        sutType = ConstantDetectionExpressionPass.self
+        sutType = LocalConstantPromotionExpressionPass.self
         intentionContext = .global(
             GlobalFunctionGenerationIntention(
                 signature: FunctionSignature(name: "test")

--- a/Tests/ExpressionPassesTests/NilValueTransformationsPassTests.swift
+++ b/Tests/ExpressionPassesTests/NilValueTransformationsPassTests.swift
@@ -6,7 +6,7 @@ class NilValueTransformationsPassTests: ExpressionPassTestCase {
     override func setUp() {
         super.setUp()
         
-        sut = NilValueTransformationsPass(context: makeContext())
+        sutType = NilValueTransformationsPass.self
     }
     
     func testTopLevelBlockInvocation() {

--- a/Tests/ExpressionPassesTests/NumberCommonsExpressionPassTests.swift
+++ b/Tests/ExpressionPassesTests/NumberCommonsExpressionPassTests.swift
@@ -7,7 +7,7 @@ class NumberCommonsExpressionPassTests: ExpressionPassTestCase {
     override func setUp() {
         super.setUp()
         
-        sut = NumberCommonsExpressionPass(context: makeContext())
+        sutType = NumberCommonsExpressionPass.self
     }
     
     func testConvertNumericCast() {

--- a/Tests/ExpressionPassesTests/UIKitExpressionPassTests.swift
+++ b/Tests/ExpressionPassesTests/UIKitExpressionPassTests.swift
@@ -28,14 +28,32 @@ class UIKitExpressionPassTests: ExpressionPassTestCase {
     }
     
     func testUIColor() {
-        assertTransformParsed(
-            expression: "[UIColor orangeColor]",
-            into: Expression.identifier("UIColor").dot("orange")
+        assertTransform(
+            expression: Expression
+                .identifier("UIColor")
+                .typed(.metatype(for: "UIColor"))
+                .dot("orangeColor")
+                .call()
+                .typed("UIColor"),
+            into: Expression
+                .identifier("UIColor")
+                .typed(.metatype(for: "UIColor"))
+                .dot("orange")
+                .typed("UIColor")
         ); assertNotifiedChange()
         
-        assertTransformParsed(
-            expression: "[UIColor redColor]",
-            into: Expression.identifier("UIColor").dot("red")
+        assertTransform(
+            expression: Expression
+                .identifier("UIColor")
+                .typed(.metatype(for: "UIColor"))
+                .dot("redColor")
+                .call()
+                .typed("UIColor"),
+            into: Expression
+                .identifier("UIColor")
+                .typed(.metatype(for: "UIColor"))
+                .dot("red")
+                .typed("UIColor")
         ); assertNotifiedChange()
         
         // Test unrecognized cases are left alone

--- a/Tests/ExpressionPassesTests/UIKitExpressionPassTests.swift
+++ b/Tests/ExpressionPassesTests/UIKitExpressionPassTests.swift
@@ -7,7 +7,7 @@ class UIKitExpressionPassTests: ExpressionPassTestCase {
     override func setUp() {
         super.setUp()
         
-        sut = UIKitExpressionPass(context: makeContext())
+        sutType = UIKitExpressionPass.self
     }
     
     func testNSTextAlignment() {

--- a/Tests/GrammarModelsTests/SourceRangeTests.swift
+++ b/Tests/GrammarModelsTests/SourceRangeTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import GrammarModels
+import GrammarModels
 
 class SourceRangeTests: XCTestCase {
     func testUnion() {

--- a/Tests/GrammarModelsTests/SourceTests.swift
+++ b/Tests/GrammarModelsTests/SourceTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import GrammarModels
+import GrammarModels
 
 class SourceTests: XCTestCase {
     

--- a/Tests/SwiftRewriterLibTests/DefaultUsageAnalyzerTests.swift
+++ b/Tests/SwiftRewriterLibTests/DefaultUsageAnalyzerTests.swift
@@ -263,6 +263,13 @@ class DefaultUsageAnalyzerTests: XCTestCase {
                     .dot("b")
                     .assignment(op: .assign, rhs: .constant(0))
             ),
+            // a[0] = 0
+            .expression(
+                Expression
+                    .identifier("a")
+                    .sub(.constant(0))
+                    .assignment(op: .assign, rhs: .constant(0))
+            ),
             // a.b?.c = 0
             .expression(
                 Expression
@@ -304,11 +311,12 @@ class DefaultUsageAnalyzerTests: XCTestCase {
         
         let usages = sut.findUsagesOf(localNamed: "a")
         
-        XCTAssertEqual(usages.count, 4)
+        XCTAssertEqual(usages.count, 5)
         XCTAssertEqual(usages[0].isReadOnlyUsage, false)
         XCTAssertEqual(usages[1].isReadOnlyUsage, false)
         XCTAssertEqual(usages[2].isReadOnlyUsage, false)
-        XCTAssertEqual(usages[3].isReadOnlyUsage, true)
+        XCTAssertEqual(usages[3].isReadOnlyUsage, false)
+        XCTAssertEqual(usages[4].isReadOnlyUsage, true)
     }
     
     func testFindUsagesOfLocalVariableDetectingWritingUsagesOfPointerType() {

--- a/Tests/SwiftRewriterLibTests/FunctionSignatureParserTests.swift
+++ b/Tests/SwiftRewriterLibTests/FunctionSignatureParserTests.swift
@@ -151,6 +151,18 @@ class FunctionSignatureParserTests: XCTestCase {
         )
     }
     
+    func testMutatingFunction() {
+        assert(string: "mutating function()",
+               parseInto: FunctionSignature(
+                name: "function",
+                parameters: [],
+                returnType: .void,
+                isStatic: false,
+                isMutating: true
+            )
+        )
+    }
+    
     func testExtraneousInputError() {
         do {
             _=try FunctionSignatureParser.parseParameters(from: "())")

--- a/Tests/SwiftRewriterLibTests/SwiftRewriter+StmtTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriter+StmtTests.swift
@@ -162,7 +162,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
         )
         assertSingleStatement(
             objc: "CGFloat x = [self offsetForDate:cell.startDate];",
-            swift: "var x: CGFloat = self.offsetForDate(cell.startDate)"
+            swift: "let x: CGFloat = self.offsetForDate(cell.startDate)"
         )
     }
     
@@ -170,7 +170,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
     func testParseBlockVarDeclaration() {
         assertSingleStatement(
             objc: "__block id value;",
-            swift: "var value: AnyObject!"
+            swift: "let value: AnyObject!"
         )
     }
     
@@ -178,7 +178,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
     func testParseUnusedVarDeclaration() {
         assertSingleStatement(
             objc: "__unused id value;",
-            swift: "var value: AnyObject!"
+            swift: "let value: AnyObject!"
         )
     }
     
@@ -189,72 +189,72 @@ class SwiftRewriter_StmtTests: XCTestCase {
     func testKeepVarTypePatternsOnNumericTypes() {
         assertSingleStatement(
             objc: "NSInteger x = 10;",
-            swift: "var x: Int = 10"
+            swift: "let x: Int = 10"
         )
         assertSingleStatement(
             objc: "NSUInteger x = 10;",
-            swift: "var x: UInt = 10"
+            swift: "let x: UInt = 10"
         )
         assertSingleStatement(
             objc: "CGFloat x = 10;",
-            swift: "var x: CGFloat = 10"
+            swift: "let x: CGFloat = 10"
         )
         assertSingleStatement(
             objc: "double x = 10;",
-            swift: "var x: CDouble = 10"
+            swift: "let x: CDouble = 10"
         )
         // Should avoid omitting types for nil values, as well
         assertSingleStatement(
             objc: "NSString *x = nil;",
-            swift: "var x: String! = nil"
+            swift: "let x: String! = nil"
         )
         
         // Keep inferring on for literal-based expressions as well
         assertSingleStatement(
             objc: "NSInteger x = 10 + 5;",
-            swift: "var x: Int = 10 + 5"
+            swift: "let x: Int = 10 + 5"
         )
         assertSingleStatement(
             objc: "NSUInteger x = 10 + 5;",
-            swift: "var x: UInt = 10 + 5"
+            swift: "let x: UInt = 10 + 5"
         )
         assertSingleStatement(
             objc: "CGFloat x = 10 + 5.0;",
-            swift: "var x: CGFloat = 10 + 5.0"
+            swift: "let x: CGFloat = 10 + 5.0"
         )
         assertSingleStatement(
             objc: "double x = 10 + 5.0;",
-            swift: "var x: CDouble = 10 + 5.0"
+            swift: "let x: CDouble = 10 + 5.0"
         )
         
         // Don't remove type signature from error-typed initializer expressions
         assertSingleStatement(
             objc: "NSInteger x = nonExistant;",
-            swift: "var x: Int = nonExistant"
+            swift: "let x: Int = nonExistant"
         )
         
         // Type expressions from non-literal sources are not needed as they can
         // be inferred
         assertSingleStatement(
             objc: "CGFloat x = self.frame.size.width;",
-            swift: "var x = self.frame.size.width"
+            swift: "let x = self.frame.size.width"
         )
 
         // Initializers from expressions with non-literal operands should also
         // omit type
         assertSingleStatement(
             objc: "CGFloat x = self.frame.size.width - 1;",
-            swift: "var x = self.frame.size.width - 1"
+            swift: "let x = self.frame.size.width - 1"
         )
 
         // No need to keep inferrence for Boolean or String types
         assertSingleStatement(
             objc: "BOOL x = YES;",
-            swift: "var x = true"
+            swift: "let x = true"
         )
         assertSingleStatement(
             objc: "NSString *x = @\"A string\";",
-            swift: "var x = \"A string\""
+            swift: "let x = \"A string\""
         )
     }
     
@@ -448,10 +448,10 @@ class SwiftRewriter_StmtTests: XCTestCase {
             class MyClass: NSObject {
                 @objc
                 func myMethod() {
-                    var local: Int = 5
+                    let local: Int = 5
                     let constLocal: Int = 5
-                    var local2: Int
-                    var localS1: Int = 5, localS2: Int
+                    let local2: Int
+                    let localS1: Int = 5, localS2: Int
                 }
             }
             """)
@@ -881,7 +881,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             class MyClass: NSObject {
                 @objc
                 func myMethod() {
-                    var count: Int = 5
+                    let count: Int = 5
                     for i in 0..<count {
                     }
                 }
@@ -906,7 +906,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             class MyClass: NSObject {
                 @objc
                 func myMethod() {
-                    var array = []
+                    let array = []
                     for i in 0..<array.count {
                     }
                 }
@@ -962,7 +962,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             class MyClass: NSObject {
                 @objc
                 func myMethod() {
-                    var count: Int = 5
+                    let count: Int = 5
                     i = 0
                     while i < count {
                         defer {

--- a/Tests/SwiftRewriterLibTests/SwiftRewriter+TypingTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriter+TypingTests.swift
@@ -1243,4 +1243,28 @@ class SwiftRewriter_TypingTests: XCTestCase {
             """,
             options: ASTWriterOptions(outputExpressionTypes: true))
     }
+    
+    /// Verifies that deeply-nested transformations are properly executed and
+    /// resulting expressions match expected type.
+    func testRewriteDeepNestedTransformations() {
+        // Here, [[UIColor lightGrayColor] colorWithAlphaComponent:0.2] features
+        // two deep transformations:
+        // [UIColor lightGrayColor] -> UIColor.lightGray
+        // [<exp> colorWithAlphaComponent:] -> <exp>.withAlphaComponent()
+        // These should be properly executed and the result be of the expected
+        // UIColor type.
+        assertObjcParse(
+            objc: """
+            void test() {
+                [[UIColor lightGrayColor] colorWithAlphaComponent:0.2];
+            }
+            """,
+            swift: """
+            func test() {
+                // type: UIColor
+                UIColor.lightGray.withAlphaComponent(0.2)
+            }
+            """,
+            options: ASTWriterOptions(outputExpressionTypes: true))
+    }
 }

--- a/Tests/SwiftRewriterLibTests/SwiftRewriter+TypingTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriter+TypingTests.swift
@@ -506,7 +506,7 @@ class SwiftRewriter_TypingTests: XCTestCase {
                 
                 @objc
                 func f1() {
-                    var _callback = self.callback
+                    let _callback = self.callback
                     // type: Void?
                     _callback?()
                 }
@@ -538,7 +538,7 @@ class SwiftRewriter_TypingTests: XCTestCase {
                 
                 @objc
                 func f1() {
-                    var _callback = self.callback
+                    let _callback = self.callback
                     // type: Void?
                     _callback?()
                 }
@@ -764,9 +764,9 @@ class SwiftRewriter_TypingTests: XCTestCase {
             class MyClass: NSObject {
                 @objc
                 func method() {
-                    var local1 = self.optional()
-                    var local2 = self.nonOptional()
-                    var local3 = self.unspecifiedOptional()
+                    let local1 = self.optional()
+                    let local2 = self.nonOptional()
+                    let local3 = self.unspecifiedOptional()
                     // type: String?
                     local1
                     // type: String
@@ -863,7 +863,7 @@ class SwiftRewriter_TypingTests: XCTestCase {
                 func method() {
                     // type: Callback
                     self.callback = { () -> Void in
-                        var local: Int
+                        let local: Int
                         // type: Int
                         local
                     }
@@ -915,7 +915,7 @@ class SwiftRewriter_TypingTests: XCTestCase {
                 
                 @objc
                 func method() {
-                    var local: Int
+                    let local: Int
                     // type: Callback
                     self.callback = { () -> Void in
                         // type: Int
@@ -960,7 +960,7 @@ class SwiftRewriter_TypingTests: XCTestCase {
             class A: NSObject {
                 @objc
                 func f1() {
-                    var a = self.other()
+                    let a = self.other()
                     // type: A?
                     a
                 }
@@ -990,7 +990,7 @@ class SwiftRewriter_TypingTests: XCTestCase {
             class A: NSObject {
                 @objc
                 func f1() {
-                    var a = self.other()
+                    let a = self.other()
                     // type: A
                     a
                 }
@@ -1201,8 +1201,8 @@ class SwiftRewriter_TypingTests: XCTestCase {
             """,
             swift: """
             func test() {
-                var array = NSMutableArray()
-                var object = array
+                let array = NSMutableArray()
+                let object = array
                 // type: Void
                 array.add(object)
             }
@@ -1236,7 +1236,7 @@ class SwiftRewriter_TypingTests: XCTestCase {
             """,
             swift: """
             func test() {
-                var f: CGFloat = 0
+                let f: CGFloat = 0
                 // type: CGFloat
                 floor(f)
             }

--- a/Tests/SwiftRewriterLibTests/SwiftRewriterTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriterTests.swift
@@ -955,7 +955,7 @@ class SwiftRewriterTests: XCTestCase {
             class MyClass: NSObject {
                 @objc
                 func method() {
-                    var aValue: NSObject!
+                    let aValue: NSObject!
                     (aValue as? String)?[123]
                 }
             }
@@ -979,7 +979,7 @@ class SwiftRewriterTests: XCTestCase {
             class MyClass: NSObject {
                 @objc
                 func method() {
-                    var aValue: NSObject!
+                    let aValue: NSObject!
                     (aValue as? String)?.someMethod()
                     (aValue as? String)?.property
                     (aValue as? String)?[123]
@@ -1364,13 +1364,13 @@ class SwiftRewriterTests: XCTestCase {
             class A: NSObject {
                 @objc
                 func recreatePath() {
-                    var top: CGFloat = startsAtTop ? 0 : circle.center.y
-                    var bottom = max(self.bounds.size.height, top)
+                    let top: CGFloat = startsAtTop ? 0 : circle.center.y
+                    let bottom = max(self.bounds.size.height, top)
                     if top == bottom {
                         shapeLayer.path = nil
                         return
                     }
-                    var path = CGMutablePath()
+                    let path = CGMutablePath()
                     path.move(to: CGPoint(x: 0, y: top))
                     path.addLine(to: CGPoint(x: 0, y: bottom))
                     shapeLayer.strokeColor = self.dateLabel.textColor.CGColor
@@ -1758,7 +1758,7 @@ class SwiftRewriterTests: XCTestCase {
                 }
                 @objc
                 func method() {
-                    var b: B?
+                    let b: B?
                     self.takesA(b?.a() ?? A())
                 }
             }
@@ -1797,7 +1797,7 @@ class SwiftRewriterTests: XCTestCase {
                 
                 @objc
                 func method() {
-                    var a: A!
+                    let a: A!
                     self.b?.c = 0
                     a.b?.c = 0
                     self.takesExpression(a.b?.c ?? 0)
@@ -1954,7 +1954,7 @@ class SwiftRewriterTests: XCTestCase {
                 
                 @objc
                 func method() {
-                    var local = Int((self.b?.value ?? 0.0) / (self.b?.value ?? 0.0))
+                    let local = Int((self.b?.value ?? 0.0) / (self.b?.value ?? 0.0))
                 }
             }
             """)
@@ -2020,7 +2020,7 @@ class SwiftRewriterTests: XCTestCase {
                 
                 @objc
                 func method() {
-                    var changedY = fabs(self.b - self.b) > FLT_EPSILON
+                    let changedY = fabs(self.b - self.b) > FLT_EPSILON
                 }
             }
             """)
@@ -2303,7 +2303,7 @@ class SwiftRewriterTests: XCTestCase {
                 
                 @objc
                 func method() {
-                    var local = GLenum(prop)
+                    let local = GLenum(prop)
                 }
             }
             """)
@@ -2335,7 +2335,7 @@ class SwiftRewriterTests: XCTestCase {
                 
                 @objc
                 func method() {
-                    var local = GLenum(prop)
+                    let local = GLenum(prop)
                 }
             }
             """)
@@ -2356,7 +2356,7 @@ class SwiftRewriterTests: XCTestCase {
             class A: NSObject {
                 @objc
                 func method() {
-                    var dict = [:]
+                    let dict = [:]
                     NSLog(dict["abc"]?["def"].value)
                 }
             }
@@ -2536,8 +2536,8 @@ class SwiftRewriterTests: XCTestCase {
             """,
             swift: """
             func test() {
-                var array = NSMutableArray()
-                var object: NSObject?
+                let array = NSMutableArray()
+                let object: NSObject?
                 if let object = object {
                     array.add(object)
                 }
@@ -2557,7 +2557,7 @@ class SwiftRewriterTests: XCTestCase {
             swift: """
             func test() {
                 Date() == Date()
-                var date: Date?
+                let date: Date?
                 date == Date()
             }
             """


### PR DESCRIPTION
Allows detecting and promoting local variables to constants when it's detected that they are not modified within scope, e.g.:

```objc
void test() {
    NSInteger a = 0;
    NSInteger b = 0;
    a = 1;
}
```

Gets transformed into:
```swift
func test() {
    var a: Int = 0
    let b: Int = 0
    a = 1
}
```

There's also some `UIColor` type definition and general type resolution/transformation improvements, thrown in.