### PR TITLE
Make 'omit objective-c compatibility' the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,21 @@ swift run -c=release SwiftRewriter --colorize --target stdout files /path/to/MyC
 Usage:
 
 ```
-SwiftRewriter [--colorize] [--print-expression-types] [--print-tracing-history] [--verbose] [--num-threads <n>] [--target stdout | filedisk]
-[files <files...> | path <path> [--exclude-pattern <pattern>] [--include-pattern <pattern>] [--skip-confirm] [--overwrite]]
+SwiftRewriter [--colorize] [--print-expression-types] [--print-tracing-history] [--emit-objc-compatibility] [--verbose] [--num-threads <n>]
+[--force-ll] [--target stdout | filedisk] [files <files...> | path <path> [--exclude-pattern <pattern>] [--include-pattern <pattern>] [--skip-confirm] [--overwrite]]
 
 OPTIONS:
   --colorize              Pass this parameter as true to enable terminal colorization during output.
   --diagnose-file         Provides a target file path to diagnose during rewriting.
 After each intention pass and after expression passes, the file is written
 to the standard output for diagnosing rewriting issues.
+  --emit-objc-compatibility
+                          Emits '@objc' attributes on definitions, and emits NSObject subclass and NSObjectProtocol conformance on protocols.
+
+This forces Swift to create Objective-C-compatible subclassing structures
+which may increase compatibility with previous Obj-C code.
+  --force-ll              Forces ANTLR parsing to use LL prediction context, instead of making an attempt at SLL first. May be more performant in some circumstances depending on complexity of original source code.
   --num-threads           Specifies the number of threads to use when performing parsing, as well as intention and expression passes. If not specified, thread allocation is defined by the system depending on usage conditions.
-  --omit-objc-compatibility
-                          Don't emit '@objc' attributes on definitions, and don't emit NSObject subclass and NSObjectProtocol conformance by default.
   --print-expression-types
                           Prints the type of each top-level resolved expression statement found in function bodies.
   --print-tracing-history
@@ -50,7 +54,7 @@ Defaults to 'filedisk' if not provided.
   --help                  Display available options
 
 SUBCOMMANDS:
-  files                   Converts one or more input .h/.m files to Swift.
+  files                   Converts one or more series of .h/.m files to Swift.
   path                    Examines a path and collects all .h/.m files to convert, before presenting a prompt to confirm conversion of files.
 ```
 

--- a/Sources/SwiftRewriter/main.swift
+++ b/Sources/SwiftRewriter/main.swift
@@ -90,13 +90,16 @@ let forceUseLLPredictionArg
         original source code.
         """)
 
-// --omit-objc-compatibility
-let omitObjcCompatibilityArg
+// --emit-objc-compatibility
+let emitObjcCompatibilityArg
     = parser.add(
-        option: "--omit-objc-compatibility", kind: Bool.self,
+        option: "--emit-objc-compatibility", kind: Bool.self,
         usage: """
-        Don't emit '@objc' attributes on definitions, and don't emit NSObject subclass \
-        and NSObjectProtocol conformance by default.
+        Emits '@objc' attributes on definitions, and emits NSObject subclass \
+        and NSObjectProtocol conformance on protocols.
+        
+        This forces Swift to create Objective-C-compatible subclassing structures
+        which may increase compatibility with previous Obj-C code.
         """)
 
 // --diagnose-file
@@ -185,7 +188,7 @@ do {
     Settings.astWriter.numThreads = result.get(numThreadsArg) ?? OperationQueue.defaultMaxConcurrentOperationCount
     Settings.astWriter.outputExpressionTypes = result.get(outputExpressionTypesArg) ?? false
     Settings.astWriter.printIntentionHistory = result.get(outputIntentionHistoryArg) ?? false
-    Settings.astWriter.omitObjcCompatibility = result.get(omitObjcCompatibilityArg) ?? false
+    Settings.astWriter.emitObjcCompatibility = result.get(emitObjcCompatibilityArg) ?? false
     Settings.rewriter.forceUseLLPrediction = result.get(forceUseLLPredictionArg) ?? false
     
     let target = result.get(targetArg) ?? .filedisk

--- a/Sources/SwiftRewriter/main.swift
+++ b/Sources/SwiftRewriter/main.swift
@@ -33,9 +33,11 @@ let parser =
     ArgumentParser(
         usage: """
         [--colorize] [--print-expression-types] [--print-tracing-history] \
-        [--verbose] [--num-threads <n>] [--target stdout | filedisk]
+        [--emit-objc-compatibility] [--verbose] [--num-threads <n>] [--force-ll] \
+        [--target stdout | filedisk] \
         [files <files...> \
-        | path <path> [--exclude-pattern <pattern>] [--skip-confirm] [--overwrite]]
+        | path <path> [--exclude-pattern <pattern>] [--include-pattern <pattern>] \
+        [--skip-confirm] [--overwrite]]
         """,
         overview: """
         Converts a set of files, or, if not provided, starts an interactive \
@@ -131,7 +133,7 @@ let targetArg
 
 let filesParser
     = parser.add(subparser: "files",
-                 overview: "Converts one or more series of files to Swift and print them to the terminal.")
+                 overview: "Converts one or more series of .h/.m files to Swift.")
 let filesArg
     = filesParser.add(positional: "files", kind: [String].self, usage: "Objective-C file(s) to convert.")
 

--- a/Sources/SwiftRewriterLib/SwiftASTWriter.swift
+++ b/Sources/SwiftRewriterLib/SwiftASTWriter.swift
@@ -19,21 +19,24 @@ public struct ASTWriterOptions {
     /// as a comment for inspection.
     public var printIntentionHistory: Bool
     
-    /// If `true`, `@objc` attributes and `: NSObject` are omitted from declarations
+    /// If `true`, `@objc` attributes and `: NSObject` are emitted for declarations
     /// during output.
-    public var omitObjcCompatibility: Bool
+    ///
+    /// This may increase compatibility with previous Objective-C code when compiled
+    /// and executed.
+    public var emitObjcCompatibility: Bool
     
     /// Number of concurrent threads to use when saving files.
     public var numThreads: Int
     
     public init(outputExpressionTypes: Bool = false,
                 printIntentionHistory: Bool = false,
-                omitObjcCompatibility: Bool = false,
+                emitObjcCompatibility: Bool = false,
                 numThreads: Int = OperationQueue.defaultMaxConcurrentOperationCount) {
         
         self.outputExpressionTypes = outputExpressionTypes
         self.printIntentionHistory = printIntentionHistory
-        self.omitObjcCompatibility = omitObjcCompatibility
+        self.emitObjcCompatibility = emitObjcCompatibility
         self.numThreads = numThreads
     }
 }

--- a/Sources/SwiftRewriterLib/SwiftWriter.swift
+++ b/Sources/SwiftRewriterLib/SwiftWriter.swift
@@ -231,7 +231,7 @@ class InternalSwiftWriter {
         
         // [@objc] enum <Name>: <RawValue> {
         target.outputIdentation()
-        if !options.omitObjcCompatibility {
+        if options.emitObjcCompatibility {
             target.outputInlineWithSpace("@objc", style: .keyword)
         }
         target.outputInlineWithSpace("enum", style: .keyword)
@@ -353,7 +353,7 @@ class InternalSwiftWriter {
         } else {
             target.output(line: "// MARK: -", style: .comment)
         }
-        if !options.omitObjcCompatibility {
+        if options.emitObjcCompatibility {
             target.output(line: "@objc", style: .keyword)
         }
         target.outputIdentation()
@@ -366,7 +366,7 @@ class InternalSwiftWriter {
     func outputClass(_ cls: ClassGenerationIntention, target: RewriterOutputTarget) {
         outputHistory(cls.history, target: target)
         
-        if !options.omitObjcCompatibility {
+        if options.emitObjcCompatibility {
             target.output(line: "@objc", style: .keyword)
         }
         target.outputIdentation()
@@ -382,7 +382,7 @@ class InternalSwiftWriter {
         if let cls = type as? ClassGenerationIntention {
             if let sup = cls.superclassName {
                 inheritances.append(sup)
-            } else if !options.omitObjcCompatibility {
+            } else if options.emitObjcCompatibility {
                 // Always inherit from NSObject, at least, in Objective-C
                 // compatibility mode.
                 inheritances.append("NSObject")
@@ -451,7 +451,7 @@ class InternalSwiftWriter {
         
         var emitObjcAttribute = true
         
-        if !options.omitObjcCompatibility {
+        if options.emitObjcCompatibility {
             // Always inherit form NSObjectProtocol in Objective-C compatibility mode
             if !inheritances.contains("NSObjectProtocol") {
                 inheritances.insert("NSObjectProtocol", at: 0)
@@ -555,7 +555,7 @@ class InternalSwiftWriter {
         
         target.outputIdentation()
         
-        if !options.omitObjcCompatibility {
+        if options.emitObjcCompatibility {
             target.outputInlineWithSpace("@objc", style: .keyword)
         }
         
@@ -681,7 +681,7 @@ class InternalSwiftWriter {
         
         outputHistory(for: initMethod, target: target)
         
-        if !options.omitObjcCompatibility && (selfType.kind == .class || selfType.kind == .protocol) {
+        if options.emitObjcCompatibility && (selfType.kind == .class || selfType.kind == .protocol) {
             target.output(line: "@objc", style: .keyword)
         }
         target.outputIdentation()
@@ -730,7 +730,7 @@ class InternalSwiftWriter {
         
         outputHistory(for: method, target: target)
         
-        if !options.omitObjcCompatibility {
+        if options.emitObjcCompatibility {
             target.output(line: "@objc", style: .keyword)
         }
         target.outputIdentation()
@@ -761,7 +761,7 @@ class InternalSwiftWriter {
         
         outputHistory(for: method, target: target)
         
-        if !options.omitObjcCompatibility {
+        if options.emitObjcCompatibility {
             target.output(line: "@objc", style: .keyword)
         }
         
@@ -776,7 +776,7 @@ class InternalSwiftWriter {
             target.outputInlineWithSpace("static", style: .keyword)
         }
         
-        if !options.omitObjcCompatibility {
+        if options.emitObjcCompatibility {
             // Protocol 'optional' keyword
             if let protocolMethod = method as? ProtocolMethodGenerationIntention, protocolMethod.isOptional {
                 target.outputInlineWithSpace("optional", style: .keyword)

--- a/Tests/SwiftRewriterLibTests/PropertyMergeIntentionPassTests.swift
+++ b/Tests/SwiftRewriterLibTests/PropertyMergeIntentionPassTests.swift
@@ -19,9 +19,8 @@ class PropertyMergeIntentionPassTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc var value: Bool {
+            class MyClass {
+                var value: Bool {
                     get {
                         return false
                     }
@@ -47,9 +46,8 @@ class PropertyMergeIntentionPassTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc var value: Bool {
+            class MyClass {
+                var value: Bool {
                     return false
                 }
             }
@@ -76,10 +74,9 @@ class PropertyMergeIntentionPassTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
+            class MyClass {
                 private var _value: Bool = false
-                @objc var value: Bool {
+                var value: Bool {
                     get {
                         return self._value
                     }
@@ -104,9 +101,8 @@ class PropertyMergeIntentionPassTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc var value: Bool {
+            class MyClass {
+                var value: Bool {
                     return false
                 }
             }
@@ -134,9 +130,8 @@ class PropertyMergeIntentionPassTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc var value: MyClass {
+            class MyClass {
+                var value: MyClass {
                     get {
                         return MyClass()
                     }
@@ -166,10 +161,9 @@ class PropertyMergeIntentionPassTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
+            class MyClass {
                 private var _ganttStartDate: Date = Date()
-                @objc var ganttStartDate: Date {
+                var ganttStartDate: Date {
                     get {
                         return _ganttStartDate
                     }

--- a/Tests/SwiftRewriterLibTests/SwiftRewriter+GlobalsProvidersTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriter+GlobalsProvidersTests.swift
@@ -17,9 +17,7 @@ class SwiftRewriter_GlobalsProvidersTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: UIView {
-                @objc
                 func method() {
                     // type: CGRect
                     self.frame

--- a/Tests/SwiftRewriterLibTests/SwiftRewriter+IntentionPassHistoryTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriter+IntentionPassHistoryTests.swift
@@ -28,11 +28,10 @@ class SwiftRewriter_IntentionPassHistoryTests: XCTestCase {
             // [Creation]  line 12 column 0
             // [PropertyMergeIntentionPass:1] Removed method MyClass.value() -> Bool since deduced it is a getter for property MyClass.value: Bool
             // [PropertyMergeIntentionPass:1] Removed method MyClass.setValue(_ value: Bool) since deduced it is a setter for property MyClass.value: Bool
-            @objc
-            class MyClass: NSObject {
+            class MyClass {
                 // [Creation]  line 13 column 0
                 // [PropertyMergeIntentionPass:1] Merged MyClass.value() -> Bool and MyClass.setValue(_ value: Bool) into property MyClass.value: Bool
-                @objc var value: Bool {
+                var value: Bool {
                     get {
                         return false
                     }
@@ -42,7 +41,6 @@ class SwiftRewriter_IntentionPassHistoryTests: XCTestCase {
                 
                 // [Creation]  line 8 column 2
                 // [TypeMerge] Updated nullability signature from () -> String! to: () -> String
-                @objc
                 func aMethod() -> String {
                 }
             }

--- a/Tests/SwiftRewriterLibTests/SwiftRewriter+MultiFilesTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriter+MultiFilesTests.swift
@@ -15,9 +15,7 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
             """)
             .translatesToSwift(
             """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                 }
             }
@@ -42,9 +40,7 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
             """)
             .translatesToSwift(
             """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                 }
             }
@@ -72,11 +68,9 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
             """)
             .translatesToSwift(
             """
-            @objc
-            class MyClass: NSObject {
-                @objc var property: String
+            class MyClass {
+                var property: String
                 
-                @objc
                 func myMethod(_ parameter: String) -> AnyObject {
                 }
             }
@@ -116,19 +110,14 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
             .translatesToSwift(
             """
             // MARK: - Extension
-            @objc
             extension MyClass {
-                @objc
                 func fromExtension() {
                 }
-                @objc
                 func fromExtensionInterfaceOnly() {
                 }
             }
             // End of file MyClass+Ext.swift
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func originalMethod() {
                 }
             }
@@ -143,7 +132,7 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
         assertThat()
             .file(name: "Class.h",
             """
-            @interface MyClass : NSObject
+            @interface MyClass
             @end
             """)
             .file(name: "Class.m",
@@ -175,24 +164,19 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
             """)
             .translatesToSwift("""
             // MARK: - Ext1
-            @objc
             extension MyClass {
-                @objc
                 func f1() {
                     stmt1()
                 }
             }
             // MARK: - Ext2
-            @objc
             extension MyClass {
-                @objc
                 func f2() {
                     stmt2()
                 }
             }
             // End of file Class+Ext.swift
-            @objc
-            class MyClass: NSObject {
+            class MyClass {
             }
             // End of file Class.swift
             """)
@@ -222,15 +206,11 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
             @end
             """)
             .translatesToSwift("""
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 init(thing: AnyObject!) {
                 }
-                @objc
                 func doThing() {
                 }
-                @objc
                 func doOtherThing() {
                 }
             }
@@ -247,7 +227,7 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
             };
             
             B *globalB;
-            @interface A: NSObject
+            @interface A
             {
                 B* ivarB;
             }
@@ -258,31 +238,27 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
             """)
             .file(name: "B.h",
             """
-            @interface B: NSObject
+            @interface B
             @end
             """)
             .translatesToSwift("""
-            @objc enum AnEnum: String {
+            enum AnEnum: String {
                 case AnEnumCase1
             }
             
             var globalB: B!
             
-            @objc
-            class A: NSObject {
+            class A {
                 private var ivarB: B!
-                @objc var b: B
+                var b: B
                 
-                @objc
                 init(b: B!) {
                 }
-                @objc
                 func takesB(_ b: B!) -> B! {
                 }
             }
             // End of file A.swift
-            @objc
-            class B: NSObject {
+            class B {
             }
             // End of file B.swift
             """)
@@ -322,17 +298,13 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
             // Preprocessor directives found in file:
             // #pragma mark - Delegate
             // #pragma mark - Calculation methods
-            @objc
-            protocol Delegate: NSObjectProtocol {
-                @objc
+            protocol Delegate {
                 func delegateMethod(_ cls: Class)
             }
 
-            @objc
             class Class: UIView {
-                @objc weak var delegate: Delegate?
+                weak var delegate: Delegate?
                 
-                @objc
                 func method() {
                     // type: Delegate?
                     self.delegate
@@ -345,8 +317,7 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
                 }
             }
             // End of file A.swift
-            """,
-            options: ASTWriterOptions(outputExpressionTypes: true))
+            """, options: ASTWriterOptions(outputExpressionTypes: true))
     }
     
     func testPreserversAssumesNonnullContextAfterMovingDeclarationsFromHeaderToImplementation() {
@@ -363,8 +334,7 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
             .translatesToSwift("""
             typealias errorBlock = (String) -> Void
 
-            @objc
-            class A: NSObject {
+            class A {
             }
             // End of file A.swift
             """)
@@ -386,9 +356,7 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
             @end
             """)
             .translatesToSwift("""
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 func method(_ param: (String) -> Void) {
                 }
             }
@@ -415,7 +383,7 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
     func testMergeAndKeepNullabilityDefinitions() {
         assertThat()
             .file(name: "A.h", """
-            @interface A : NSObject
+            @interface A
             @property CGFloat width;
             @end
             """)
@@ -424,7 +392,7 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
             @end
             """)
             .file(name: "B.h", """
-            @interface B : NSObject
+            @interface B
             @property (nullable) A* a;
             - (void)takesCGFloat:(CGFloat)f;
             @end
@@ -439,20 +407,16 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
             @end
             """)
             .translatesToSwift("""
-            @objc
-            class A: NSObject {
-                @objc var width: CGFloat = 0.0
+            class A {
+                var width: CGFloat = 0.0
             }
             // End of file A.swift
-            @objc
-            class B: NSObject {
-                @objc var a: A?
+            class B {
+                var a: A?
                 
-                @objc
                 func method() {
                     self.takesCGFloat(a?.width ?? 0.0)
                 }
-                @objc
                 func takesCGFloat(_ f: CGFloat) {
                 }
             }
@@ -481,11 +445,9 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
             """)
             .translatesToSwift(
             """
-            @objc
             class A: UIView {
-                @objc var b: B?
+                var b: B?
                 
-                @objc
                 func test() {
                     // type: CGRect?
                     self.window?.bounds
@@ -494,7 +456,6 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
                 }
             }
             // End of file A.swift
-            @objc
             class B: UIView {
             }
             // End of file B.swift
@@ -511,7 +472,7 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
             @end
             """)
             .file(name: "Class.h", """
-            @interface Class: NSObject
+            @interface Class
             @end
             """)
             .file(name: "Class.m", """
@@ -536,20 +497,16 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
                 
         assert
             .expectSwiftFile(name: "Class.swift", """
-            @objc
-            class Class: NSObject {
+            class Class {
             }
             // End of file Class.swift
             """)
             .expectSwiftFile(name: "Class+Protocol.swift", """
             // MARK: - Protocol
-            @objc
             extension Class: Protocol {
-                @objc
                 func protocolRequirement() -> String? {
                     return nil
                 }
-                @objc
                 func otherProtocolRequirement() -> String {
                     return ""
                 }
@@ -557,11 +514,8 @@ class SwiftRewriter_MultiFilesTests: XCTestCase {
             // End of file Class+Protocol.swift
             """)
             .expectSwiftFile(name: "Protocol.swift", """
-            @objc
-            protocol Protocol: NSObjectProtocol {
-                @objc
+            protocol Protocol {
                 func protocolRequirement() -> String?
-                @objc
                 func otherProtocolRequirement() -> String
             }
             // End of file Protocol.swift

--- a/Tests/SwiftRewriterLibTests/SwiftRewriter+SourcePreprocessor.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriter+SourcePreprocessor.swift
@@ -19,8 +19,7 @@ class SwiftRewriter_SourcePreprocessor: XCTestCase {
         try rewriter.rewrite()
         
         XCTAssertEqual(output.buffer, """
-            @objc
-            class MyClass: NSObject {
+            class MyClass {
             }
             """)
     }

--- a/Tests/SwiftRewriterLibTests/SwiftRewriter+StmtTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriter+StmtTests.swift
@@ -330,9 +330,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
                 }
             }
 
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     MemoryLayout<VertexObject>.size
                 }
@@ -353,9 +351,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     self.doThing(a) { () -> Void in
                     }
@@ -376,9 +372,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     { () -> Void in
                     }
@@ -394,9 +388,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     let myBlock: (() -> Void)! = {
                     }
@@ -414,9 +406,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     let myBlock: (() -> Void)! = {
                         self.doThing()
@@ -444,9 +434,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             var myInt: Int
             var myInt2: Int = 5
             
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     let local: Int = 5
                     let constLocal: Int = 5
@@ -489,9 +477,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     if true {
                         stmt(abc)
@@ -518,9 +504,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     if true {
                         stmt1()
@@ -548,9 +532,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     if true {
                         stmt1()
@@ -579,9 +561,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     if true {
                         stmt1()
@@ -608,9 +588,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     if true {
                         if true {
@@ -634,9 +612,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     if ({
                         a -= 10
@@ -665,9 +641,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     switch value {
                     case 0:
@@ -698,9 +672,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     switch value {
                     case 0:
@@ -734,9 +706,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     switch value {
                     case 0:
@@ -771,9 +741,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     switch value {
                     case 0:
@@ -802,9 +770,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     while true {
                         stmt()
@@ -828,9 +794,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     for i in 0..<10 {
                     }
@@ -852,9 +816,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     let count: Int = 5
                     for i in 0..<count {
@@ -877,9 +839,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     let count: Int = 5
                     for i in 0..<count {
@@ -902,9 +862,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     let array = []
                     for i in 0..<array.count {
@@ -928,9 +886,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     var count: Int = 5
                     var i: Int = 0
@@ -958,9 +914,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     let count: Int = 5
                     i = 0
@@ -987,9 +941,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     repeat {
                         stmt()
@@ -1012,9 +964,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     let _lockTarget = self
                     objc_sync_enter(_lockTarget)
@@ -1039,9 +989,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     autoreleasepool { () -> Void in
                         stuff()
@@ -1062,9 +1010,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     for obj in anArray {
                     }
@@ -1106,9 +1052,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     // label:
                     if true {
@@ -1136,9 +1080,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     // label:
                     if true {
@@ -1160,9 +1102,7 @@ private extension SwiftRewriter_StmtTests {
             @end
             """
         let swift = """
-            @objc
             class MyClass: UIView {
-                @objc
                 func myMethod() {
                     \(swift)
                 }

--- a/Tests/SwiftRewriterLibTests/SwiftRewriter+ThreadingTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriter+ThreadingTests.swift
@@ -62,15 +62,13 @@ private extension SwiftRewriter_ThreadingTests {
             """
             
             expectedSwift += """
-            @objc
             class \(className): UIView {
-                @objc weak var next: \(className)?
-                @objc var a: Bool = false
-                @objc var b: Bool = false
-                @objc var c: CGFloat = 0.0
+                weak var next: \(className)?
+                var a: Bool = false
+                var b: Bool = false
+                var c: CGFloat = 0.0
                 \
             
-                @objc
                 func myMethod() {
                     var i: CInt = 0
                     while i < CInt(self.myOtherMethod()) {
@@ -82,7 +80,6 @@ private extension SwiftRewriter_ThreadingTests {
                     }
                     self.window?.bounds
                 }
-                @objc
                 func myOtherMethod() -> CGFloat {
                     return (10 + (next?.c ?? 0.0)) / 2
                 }

--- a/Tests/SwiftRewriterLibTests/SwiftRewriter+TypingTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriter+TypingTests.swift
@@ -21,9 +21,7 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class MyClass: NSObject {
-                @objc
                 func method() {
                     // type: MyClass
                     self
@@ -68,29 +66,26 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class MyClass: NSObject {
-                @objc static var a: Bool {
+                static var a: Bool {
                     // type: MyClass.Type
                     self
                     // type: NSObject.Type
                     super
                 }
-                @objc var b: Bool {
+                var b: Bool {
                     // type: MyClass
                     self
                     // type: NSObject
                     super
                 }
                 
-                @objc
                 static func classMethod() {
                     // type: MyClass.Type
                     self
                     // type: NSObject.Type
                     super
                 }
-                @objc
                 func instanceMethod() {
                     // type: MyClass
                     self
@@ -122,9 +117,8 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class MyClass: NSObject {
-                @objc var value: Bool {
+                var value: Bool {
                     get {
                         // type: MyClass
                         self
@@ -158,9 +152,7 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class MyClass: NSObject {
-                @objc
                 static func method() {
                     // type: MyClass
                     self.init()
@@ -186,11 +178,9 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class MyClass: NSObject {
-                @objc var aValue: Int = 0
+                var aValue: Int = 0
                 
-                @objc
                 func method() {
                     // type: Int
                     self.aValue
@@ -218,14 +208,11 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class MyClass: NSObject {
-                @objc
                 func method1() {
                     // type: Int
                     self.method2()
                 }
-                @objc
                 func method2() -> Int {
                     return 0
                 }
@@ -252,14 +239,11 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class MyClass: NSObject {
-                @objc
                 static func method1() {
                     // type: Int
                     self.method2()
                 }
-                @objc
                 static func method2() -> Int {
                     return 0
                 }
@@ -291,17 +275,13 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
-                @objc
                 func method() {
                     // type: B
                     B(value: 0)
                 }
             }
-            @objc
             class B: NSObject {
-                @objc
                 init(value: Int) {
                     // type: Int
                     value
@@ -321,9 +301,7 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 func method(_ value: Int) {
                     // type: Int
                     value
@@ -349,9 +327,8 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
-                @objc var value: Bool {
+                var value: Bool {
                     get {
                         return false
                     }
@@ -382,9 +359,8 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
-                @objc var value: Bool {
+                var value: Bool {
                     get {
                         return false
                     }
@@ -416,12 +392,10 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
                 private var field: Int = 0
-                @objc var value: Bool = false
+                var value: Bool = false
                 
-                @objc
                 func f1() {
                     // type: Bool
                     self.value
@@ -443,9 +417,7 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 func f1(_ value: A!) {
                     // type: A!
                     value
@@ -470,11 +442,9 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
-                @objc var prop: Int = 0
+                var prop: Int = 0
                 
-                @objc
                 func f1(_ value: A!) {
                     // type: Int
                     value.prop
@@ -500,11 +470,9 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
                 private var callback: (() -> Void)?
                 
-                @objc
                 func f1() {
                     let _callback = self.callback
                     // type: Void?
@@ -532,11 +500,9 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
                 private var callback: (() -> Void)?
                 
-                @objc
                 func f1() {
                     let _callback = self.callback
                     // type: Void?
@@ -561,11 +527,9 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
-                @objc var b: NSObject?
+                var b: NSObject?
                 
-                @objc
                 func method() {
                     // type: Bool?
                     b?.responds(to: Selector("abc:"))
@@ -593,17 +557,13 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class B: NSObject {
-                @objc
                 func method() -> B {
                 }
             }
-            @objc
             class A: NSObject {
-                @objc var b: B?
+                var b: B?
                 
-                @objc
                 func method() {
                     // type: B?
                     self.b?.method().method()
@@ -631,17 +591,13 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class B: NSObject {
-                @objc
                 func method() -> B? {
                 }
             }
-            @objc
             class A: NSObject {
-                @objc var b: B?
+                var b: B?
                 
-                @objc
                 func method() {
                     // type: B?
                     self.b?.method()?.method()
@@ -671,15 +627,12 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            protocol B: NSObjectProtocol {
+            protocol B {
             }
 
-            @objc
             class A: NSObject {
-                @objc weak var b: B?
+                weak var b: B?
                 
-                @objc
                 func method() {
                     // type: Bool?
                     self.b?.responds(to: Selector("abc:"))
@@ -713,20 +666,16 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            protocol A: NSObjectProtocol {
-                @objc var a: Bool { get set }
+            protocol A {
+                var a: Bool { get set }
             }
-            @objc
-            protocol B: NSObjectProtocol {
-                @objc var b: Int { get set }
+            protocol B {
+                var b: Int { get set }
             }
 
-            @objc
             class C: NSObject {
-                @objc var composed: (A & B)!
+                var composed: (A & B)!
                 
-                @objc
                 func method() {
                     // type: (A & B)!
                     self.composed
@@ -761,9 +710,7 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func method() {
                     let local1 = self.optional()
                     let local2 = self.nonOptional()
@@ -775,13 +722,10 @@ class SwiftRewriter_TypingTests: XCTestCase {
                     // type: String?
                     local3
                 }
-                @objc
                 func optional() -> String? {
                 }
-                @objc
                 func nonOptional() -> String {
                 }
-                @objc
                 func unspecifiedOptional() -> String! {
                 }
             }
@@ -813,11 +757,9 @@ class SwiftRewriter_TypingTests: XCTestCase {
             swift: """
             typealias Callback = (Int) -> Void
 
-            @objc
-            class MyClass: NSObject {
-                @objc var callback: Callback
+            class MyClass {
+                var callback: Callback
                 
-                @objc
                 func method() {
                     // type: Callback
                     self.callback = { (arg: Int) -> Void in
@@ -856,11 +798,9 @@ class SwiftRewriter_TypingTests: XCTestCase {
             swift: """
             typealias Callback = () -> Void
 
-            @objc
-            class MyClass: NSObject {
-                @objc var callback: Callback
+            class MyClass {
+                var callback: Callback
                 
-                @objc
                 func method() {
                     // type: Callback
                     self.callback = { () -> Void in
@@ -910,11 +850,9 @@ class SwiftRewriter_TypingTests: XCTestCase {
             func takesBlock(_ block: (() -> Void)!) -> String! {
             }
 
-            @objc
-            class MyClass: NSObject {
-                @objc var callback: Callback
+            class MyClass {
+                var callback: Callback
                 
-                @objc
                 func method() {
                     let local: Int
                     // type: Callback
@@ -935,7 +873,6 @@ class SwiftRewriter_TypingTests: XCTestCase {
                     // type: Int
                     local
                 }
-                @objc
                 func takesBlock(_ block: (() -> Void)!) {
                 }
             }
@@ -957,15 +894,12 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 func f1() {
                     let a = self.other()
                     // type: A?
                     a
                 }
-                @objc
                 func other() -> A! {
                 }
             }
@@ -987,15 +921,12 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 func f1() {
                     let a = self.other()
                     // type: A
                     a
                 }
-                @objc
                 func other() -> A {
                 }
             }
@@ -1022,9 +953,7 @@ class SwiftRewriter_TypingTests: XCTestCase {
             func globalFunc() {
             }
             
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 func f1() {
                     // type: Int
                     global
@@ -1049,14 +978,11 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: UIView {
             }
 
             // MARK: - B
-            @objc
             extension A {
-                @objc
                 func f1() {
                     // type: CGRect?
                     self.window?.bounds
@@ -1082,7 +1008,6 @@ class SwiftRewriter_TypingTests: XCTestCase {
                 A()
             }
             
-            @objc
             class A: UIView {
             }
             """,
@@ -1105,9 +1030,7 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: UIView {
-                @objc
                 func method() {
                     // type: UIWindow?
                     self.window
@@ -1115,7 +1038,6 @@ class SwiftRewriter_TypingTests: XCTestCase {
             }
 
             // MARK: - Category
-            @objc
             extension UIView {
             }
             """,
@@ -1134,9 +1056,7 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     for i in 0..<10 {
                         // type: Int
@@ -1167,11 +1087,9 @@ class SwiftRewriter_TypingTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: UIView {
-                @objc var a: UIView?
+                var a: UIView?
                 
-                @objc
                 func method() {
                     // type: CGRect
                     self.convert(CGRect.zero, to: nil)

--- a/Tests/SwiftRewriterLibTests/SwiftRewriterTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriterTests.swift
@@ -20,7 +20,6 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class MyClass: NSObject {
             }
             """)
@@ -33,8 +32,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
+            class MyClass {
             }
             """)
     }
@@ -46,7 +44,6 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class MyClass: UIView {
             }
             """)
@@ -62,7 +59,6 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class MyClass: MyBaseClass {
             }
             """)
@@ -75,7 +71,6 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class MyClass: UIView, UITableViewDelegate {
             }
             """)
@@ -90,7 +85,7 @@ class SwiftRewriterTests: XCTestCase {
             };
             """,
             swift: """
-            @objc enum MyEnum: Int {
+            enum MyEnum: Int {
                 case MyEnumCase1 = 0
                 case MyEnumCase2
             }
@@ -105,9 +100,8 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc weak var myClass: MyClass?
+            class MyClass {
+                weak var myClass: MyClass?
             }
             """)
     }
@@ -120,9 +114,8 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc static var myClass: MyClass!
+            class MyClass {
+                static var myClass: MyClass!
             }
             """)
     }
@@ -145,19 +138,18 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc var someField: Bool = false
-                @objc var someOtherField: Int = 0
-                @objc var aRatherStringlyField: String
-                @objc var specifiedNull: String?
-                @objc var nonNullWithQualifier: String
-                @objc var nonSpecifiedNull: String!
-                @objc var idType: AnyObject!
-                @objc weak var delegate: (MyDelegate & MyDataSource)?
-                @objc var tableWithDataSource: UITableView & UITableViewDataSource
-                @objc weak var weakViewWithDelegate: (UIView & UIDelegate)?
-                @objc unowned(unsafe) var assignProp: MyClass
+            class MyClass {
+                var someField: Bool = false
+                var someOtherField: Int = 0
+                var aRatherStringlyField: String
+                var specifiedNull: String?
+                var nonNullWithQualifier: String
+                var nonSpecifiedNull: String!
+                var idType: AnyObject!
+                weak var delegate: (MyDelegate & MyDataSource)?
+                var tableWithDataSource: UITableView & UITableViewDataSource
+                weak var weakViewWithDelegate: (UIView & UIDelegate)?
+                unowned(unsafe) var assignProp: MyClass
             }
             """)
     }
@@ -178,17 +170,15 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class SomeType: NSObject {
             }
-            @objc
-            class MyClass: NSObject {
-                @objc var nontypedArray: NSArray
-                @objc var nontypedArrayNull: NSArray?
-                @objc var stringArray: [String]!
-                @objc var clsArray: [SomeType]
-                @objc var clsArrayNull: [SomeType]?
-                @objc var delegateable: SomeType & SomeDelegate
+            class MyClass {
+                var nontypedArray: NSArray
+                var nontypedArrayNull: NSArray?
+                var stringArray: [String]!
+                var clsArray: [SomeType]
+                var clsArrayNull: [SomeType]?
+                var delegateable: SomeType & SomeDelegate
             }
             """)
     }
@@ -204,8 +194,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
+            class MyClass {
                 private var _myString: String!
                 private weak var _delegate: AnyObject?
             }
@@ -220,9 +209,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                 }
             }
@@ -237,9 +224,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 static func myMethod() {
                 }
             }
@@ -259,24 +244,17 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                 }
-                @objc
                 func myOtherMethod(_ abc: Int, aString str: String) -> Int {
                 }
-                @objc
                 func myAnonParamMethod(_ abc: Int, _ str: String) -> Int {
                 }
-                @objc
                 func someNullArray() -> NSArray? {
                 }
-                @objc
                 func __(_ a: AnyObject!) {
                 }
-                @objc
                 func __(_ a: AnyObject!) -> AnyObject! {
                 }
             }
@@ -293,15 +271,11 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 override init() {
                 }
-                @objc
                 init(thing: AnyObject!) {
                 }
-                @objc
                 init(number: NSNumber) {
                 }
             }
@@ -318,9 +292,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 deinit {
                     thing()
                 }
@@ -341,8 +313,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
+            class MyClass {
                 private var _myString: String!
                 weak var _delegate: AnyObject?
                 public var _myInt: Int = 0
@@ -362,8 +333,7 @@ class SwiftRewriterTests: XCTestCase {
             NS_ASSUME_NONNULL_END
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
+            class MyClass {
                 private var _myString: String
             }
             """)
@@ -387,13 +357,10 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 init(thing: AnyObject!) {
                     self.thing()
                 }
-                @objc
                 func myMethod() {
                     self.thing()
                 }
@@ -428,24 +395,19 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
+            class MyClass {
                 private var anIVar: Int = 0
                 
-                @objc
                 init(thing: AnyObject!) {
                     self.thing()
                 }
-                @objc
                 func myMethod() {
                     self.thing()
                 }
             }
             
             // MARK: -
-            @objc
             extension MyClass: MyDelegate {
-                @objc
                 func methodFromCategory() {
                 }
             }
@@ -470,13 +432,10 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 init(thing: AnyObject) {
                     self.thing()
                 }
-                @objc
                 func myMethod() {
                     self.thing()
                 }
@@ -495,15 +454,11 @@ class SwiftRewriterTests: XCTestCase {
             - (NSString*)myMethod:(NSObject*)object;
             @end
             """, swift: """
-            @objc
-            protocol MyProtocol: NSObjectProtocol {
-                @objc
+            protocol MyProtocol {
                 func myMethod(_ object: NSObject?) -> String
             }
             
-            @objc
             class MyClass: NSObject, MyProtocol {
-                @objc
                 func myMethod(_ object: NSObject?) -> String {
                 }
             }
@@ -524,9 +479,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod(_ aParamy: Bool) {
                     thing()
                 }
@@ -543,9 +496,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func doSomething(with color: CGColor) {
                 }
             }
@@ -679,12 +630,9 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class AClass: NSObject {
-                @objc
+            class AClass {
                 func aBlocky(_ blocky: (() -> Void)!) {
                 }
-                @objc
                 func aBlockyWithString(_ blocky: (String) -> Void) {
                 }
             }
@@ -703,8 +651,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
+            class MyClass {
                 private var callback: (NSObject?) -> Void
                 private var anotherCallback: ((String) -> Void)!
                 private var yetAnotherCallback: ((String) -> NSObject?)?
@@ -722,8 +669,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
+            class MyClass {
                 private var callback: (((() -> AnyObject?)?) -> Void)!
             }
             """)
@@ -742,15 +688,11 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass1: NSObject {
-                @objc
+            class MyClass1 {
                 func aMethod(_ param: String) -> AnyObject {
                 }
             }
-            @objc
-            class MyClass2: NSObject {
-                @objc
+            class MyClass2 {
                 func aMethod(_ param: String!) -> AnyObject! {
                 }
             }
@@ -771,9 +713,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func aMethod(_ param: String) -> AnyObject {
                 }
             }
@@ -792,8 +732,7 @@ class SwiftRewriterTests: XCTestCase {
             let kMethodKey: String = "method"
             var kCodeOperatorKey: String = "codigo_operador"
             
-            @objc
-            class MyClass: NSObject {
+            class MyClass {
             }
             """)
     }
@@ -810,9 +749,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func myMethod() {
                     if self.responds(to: Selector("abc:")) {
                         thing()
@@ -830,9 +767,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            protocol MyProtocol: NSObjectProtocol {
-                @objc
+            protocol MyProtocol {
                 func myMethod()
             }
             """)
@@ -848,6 +783,7 @@ class SwiftRewriterTests: XCTestCase {
             swift: """
             @objc
             protocol MyProtocol: NSObjectProtocol {
+                @objc
                 func myMethod()
             }
             """,
@@ -870,15 +806,11 @@ class SwiftRewriterTests: XCTestCase {
             swift: """
             @objc
             protocol MyProtocol: NSObjectProtocol {
-                @objc
                 optional func myMethod()
-                @objc
                 optional func myMethod2()
             }
 
-            @objc
             class A: NSObject, MyProtocol {
-                @objc
                 func myMethod2() {
                 }
             }
@@ -899,13 +831,9 @@ class SwiftRewriterTests: XCTestCase {
             """, swift: """
             @objc
             protocol MyProtocol: NSObjectProtocol {
-                @objc
                 func f1()
-                @objc
                 optional func f2()
-                @objc
                 optional func f3()
-                @objc
                 func f4()
             }
             """)
@@ -919,10 +847,9 @@ class SwiftRewriterTests: XCTestCase {
             @property (readonly) BOOL value2;
             @end
             """, swift: """
-            @objc
-            protocol MyProtocol: NSObjectProtocol {
-                @objc var value1: Bool { get set }
-                @objc var value2: Bool { get }
+            protocol MyProtocol {
+                var value1: Bool { get set }
+                var value2: Bool { get }
             }
             """)
     }
@@ -944,14 +871,12 @@ class SwiftRewriterTests: XCTestCase {
             weak var aWeakGlobal: NSObject?
             var anIntGlobal: Int
             
-            @objc
             class AClass: NSObject {
             }
-            @objc
-            class MyClass: NSObject {
-                @objc unowned(unsafe) var aClass: AClass!
-                @objc var anInt: Int = 0
-                @objc var aProperInt: Int = 0
+            class MyClass {
+                unowned(unsafe) var aClass: AClass!
+                var anInt: Int = 0
+                var aProperInt: Int = 0
             }
             """)
     }
@@ -1002,9 +927,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func method() {
                     let aValue: NSObject!
                     (aValue as? String)?[123]
@@ -1026,9 +949,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class MyClass: NSObject {
-                @objc
+            class MyClass {
                 func method() {
                     let aValue: NSObject!
                     (aValue as? String)?.someMethod()
@@ -1051,10 +972,8 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class B: NSObject {
             }
-            @objc
             class A: NSObject {
                 private var _u: RACSubject<[B]>!
             }
@@ -1298,8 +1217,7 @@ class SwiftRewriterTests: XCTestCase {
             func global() -> A! {
             }
             
-            @objc
-            class A: NSObject {
+            class A {
             }
             """)
     }
@@ -1322,9 +1240,7 @@ class SwiftRewriterTests: XCTestCase {
             }
             @end
             """, swift: """
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 override func finishRequested(_ completion: (() -> Void)!) {
                     super.finishRequested { () -> Void in
                         _updateLink.invalidate()
@@ -1353,9 +1269,7 @@ class SwiftRewriterTests: XCTestCase {
             }
             @end
             """, swift: """
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 func loadDataWithCallback(_ callback: ((NSArray?, Error?) -> Void)!) {
                     self.doThing().then { (results: NSArray!) -> Void in
                         callback?(results, nil)
@@ -1411,9 +1325,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 func recreatePath() {
                     let top: CGFloat = startsAtTop ? 0 : circle.center.y
                     let bottom = max(self.bounds.size.height, top)
@@ -1452,13 +1364,11 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc enum MyEnum: Int {
+            enum MyEnum: Int {
                 case MyEnumCase
             }
 
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 func method() {
                     MyEnum.MyEnumCase
                 }
@@ -1476,11 +1386,9 @@ class SwiftRewriterTests: XCTestCase {
             """,
             swift: """
             // MARK: - Extension
-            @objc
             extension String {
             }
             // MARK: - Extension
-            @objc
             extension Date {
             }
             """)
@@ -1520,12 +1428,11 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc enum E: Int {
+            enum E: Int {
                 case E_1
             }
 
-            @objc
-            class A: NSObject {
+            class A {
                 private var _a: Bool = false
                 private var _b: Int = 0
                 private var _c: UInt = 0
@@ -1536,15 +1443,15 @@ class SwiftRewriterTests: XCTestCase {
                 private var _g: E
                 private var _h: String
                 private let _i: String! = nil
-                @objc var a: Bool = false
-                @objc var b: Int = 0
-                @objc var c: UInt = 0
-                @objc var d: CFloat = 0.0
-                @objc var e: CDouble = 0.0
-                @objc var e: CGFloat = 0.0
-                @objc var f: String!
-                @objc var g: E
-                @objc var h: String
+                var a: Bool = false
+                var b: Int = 0
+                var c: UInt = 0
+                var d: CFloat = 0.0
+                var e: CDouble = 0.0
+                var e: CGFloat = 0.0
+                var f: String!
+                var g: E
+                var h: String
             }
             """)
     }
@@ -1564,14 +1471,11 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 func method() {
                     A()
                     A()
                 }
-                @objc
                 static func method2() {
                     self.init()
                     self.init()
@@ -1580,7 +1484,7 @@ class SwiftRewriterTests: XCTestCase {
             """)
     }
     
-    func testOmitObjcAttribute() {
+    func testEmitObjcAttribute() {
         assertObjcParse(
             objc: """
             typedef NS_ENUM(NSInteger, Enum) {
@@ -1602,14 +1506,15 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            enum Enum: Int {
+            @objc enum Enum: Int {
                 case Enum_A
             }
             
             @objc
             protocol A: NSObjectProtocol {
-                var b: Bool { get set }
+                @objc var b: Bool { get set }
                 
+                @objc
                 func method()
             }
             
@@ -1649,25 +1554,19 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 override init(thing: A!) {
                     super.init(thing: thing)
                 }
-                @objc
                 init(otherThing thing: A!) {
                     super.init(thing: thing)
                 }
-                @objc
                 override func a() {
                     super.a()
                 }
-                @objc
                 override func b(_ a: Int) {
                     super.b(a)
                 }
-                @objc
                 func c(_ a: Int) {
                     super.c()
                 }
@@ -1687,15 +1586,11 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 func method() {
                 }
             }
-            @objc
             class B: A {
-                @objc
                 override func method() {
                 }
             }
@@ -1715,15 +1610,11 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            protocol A: NSObjectProtocol {
-                @objc
+            protocol A {
                 func method()
             }
             
-            @objc
             class B: NSObject, A {
-                @objc
                 func method() {
                 }
             }
@@ -1749,22 +1640,18 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class A: NSObject {
-                @objc var a: A?
-                @objc var b: Int = 0
+            class A {
+                var a: A?
+                var b: Int = 0
                 
-                @objc
                 func method() {
                     self.takesInt(a?.b ?? 0)
                     self.takesInt(a?.returnsInt() ?? 0)
                     self.takesInt((a?.b ?? 0) + 0)
                     self.takesInt((a?.returnsInt() ?? 0) + 0)
                 }
-                @objc
                 func takesInt(_ a: Int) {
                 }
-                @objc
                 func returnsInt() -> Int {
                 }
             }
@@ -1802,15 +1689,11 @@ class SwiftRewriterTests: XCTestCase {
                 }
             }
 
-            @objc
-            class B: NSObject {
-                @objc
+            class B {
                 func a() -> A {
                 }
-                @objc
                 func takesA(_ a: A) {
                 }
-                @objc
                 func method() {
                     let b: B?
                     self.takesA(b?.a() ?? A())
@@ -1841,22 +1724,18 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class B: NSObject {
-                @objc var c: Int = 0
+            class B {
+                var c: Int = 0
             }
-            @objc
-            class A: NSObject {
-                @objc weak var b: B?
+            class A {
+                weak var b: B?
                 
-                @objc
                 func method() {
                     let a: A!
                     self.b?.c = 0
                     a.b?.c = 0
                     self.takesExpression(a.b?.c ?? 0)
                 }
-                @objc
                 func takesExpression(_ a: Int) {
                 }
             }
@@ -1881,20 +1760,16 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class B: NSObject {
+            class B {
             }
-            @objc
-            class A: NSObject {
-                @objc var b: B?
+            class A {
+                var b: B?
                 
-                @objc
                 func method() {
                     if let b = self.b {
                         self.takesB(b)
                     }
                 }
-                @objc
                 func takesB(_ b: B) {
                 }
             }
@@ -1909,9 +1784,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 static func makeA() -> A! {
                 }
             }
@@ -1937,14 +1810,11 @@ class SwiftRewriterTests: XCTestCase {
             swift: """
             typealias block = (String) -> Void
 
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 func method() {
                     self.takesBlock { (a: String) -> Void in
                     }
                 }
-                @objc
                 func takesBlock(_ a: block) {
                 }
             }
@@ -1966,12 +1836,10 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class A: NSObject {
-                @objc var bounds: CGRect = CGRect()
-                @objc weak var parent: A?
+            class A {
+                var bounds: CGRect = CGRect()
+                weak var parent: A?
                 
-                @objc
                 func method() {
                     self.bounds.insetBy(dx: 1, dy: 2)
                     self.bounds = (self.parent?.bounds ?? CGRect()).insetBy(dx: 1, dy: 2)
@@ -1998,15 +1866,12 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class B: NSObject {
-                @objc var value: CGFloat = 0.0
+            class B {
+                var value: CGFloat = 0.0
             }
-            @objc
-            class A: NSObject {
-                @objc var b: B?
+            class A {
+                var b: B?
                 
-                @objc
                 func method() {
                     let local = Int((self.b?.value ?? 0.0) / (self.b?.value ?? 0.0))
                 }
@@ -2035,19 +1900,15 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class B: NSObject {
-                @objc var value: CGFloat = 0.0
+            class B {
+                var value: CGFloat = 0.0
             }
-            @objc
-            class A: NSObject {
-                @objc var b: B?
+            class A {
+                var b: B?
                 
-                @objc
                 func method(_ b: B) {
                     self.takesF(b.value)
                 }
-                @objc
                 func takesF(_ value: CGFloat) {
                 }
             }
@@ -2068,11 +1929,9 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
-                @objc var b: CGFloat = 0.0
+                var b: CGFloat = 0.0
                 
-                @objc
                 func method() {
                     let changedY = fabs(self.b - self.b) > FLT_EPSILON
                 }
@@ -2094,14 +1953,12 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
                 private var _a: Int = 0
-                @objc var a: Int {
+                var a: Int {
                     return self._a
                 }
                 
-                @objc
                 func method() {
                     self._a = 0
                 }
@@ -2121,10 +1978,9 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
                 private var b: Int = 0
-                @objc var a: Int {
+                var a: Int {
                     get {
                         return b
                     }
@@ -2148,10 +2004,9 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
                 private var b: Int = 0
-                @objc var a: Int {
+                var a: Int {
                     return b
                 }
             }
@@ -2170,9 +2025,8 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
-                @objc var a: Int = 0
+                var a: Int = 0
             }
             """)
     }
@@ -2192,10 +2046,9 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
                 private var b: Int = 0
-                @objc var a: Int {
+                var a: Int {
                     get {
                         return b
                     }
@@ -2219,9 +2072,8 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
-                @objc var a: Int = 0
+                var a: Int = 0
             }
             """)
     }
@@ -2251,12 +2103,11 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
-                @objc private(set) var a: NSMutableString!
-                @objc var b: NSMutableString!
-                @objc var c: NSMutableString!
-                @objc var d: NSMutableString!
+                private(set) var a: NSMutableString!
+                var b: NSMutableString!
+                var c: NSMutableString!
+                var d: NSMutableString!
             }
             """)
     }
@@ -2279,10 +2130,9 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
                 private var b: Int = 0
-                @objc var a: Int {
+                var a: Int {
                     get {
                         return b
                     }
@@ -2293,7 +2143,6 @@ class SwiftRewriterTests: XCTestCase {
             }
 
             // MARK: - category
-            @objc
             extension A {
             }
             """)
@@ -2321,11 +2170,9 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: NSObject {
-                @objc private(set) var a: Int = 0
+                private(set) var a: Int = 0
                 
-                @objc
                 func method() {
                     self.a = 0
                 }
@@ -2351,11 +2198,9 @@ class SwiftRewriterTests: XCTestCase {
             swift: """
             typealias GLenum = UInt32
             
-            @objc
-            class A: NSObject {
-                @objc var prop: CGFloat = 0.0
+            class A {
+                var prop: CGFloat = 0.0
                 
-                @objc
                 func method() {
                     let local = GLenum(prop)
                 }
@@ -2383,11 +2228,9 @@ class SwiftRewriterTests: XCTestCase {
             typealias GLenum = UInt32
             typealias Alias = GLenum
 
-            @objc
-            class A: NSObject {
-                @objc var prop: CGFloat = 0.0
+            class A {
+                var prop: CGFloat = 0.0
                 
-                @objc
                 func method() {
                     let local = GLenum(prop)
                 }
@@ -2406,9 +2249,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 func method() {
                     let dict = [:]
                     NSLog(dict["abc"]?["def"].value)
@@ -2429,9 +2270,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: UITableViewCell {
-                @objc
                 func method() {
                     self.isHidden
                 }
@@ -2456,11 +2295,9 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class A: NSObject {
-                @objc var a: Int = 0
+            class A {
+                var a: Int = 0
                 
-                @objc
                 override init() {
                     self.a = 0
                     super.init()
@@ -2482,9 +2319,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 init?(thing: Int) {
                     return self
                 }
@@ -2505,9 +2340,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 init?(thing: Int) {
                     return nil
                 }
@@ -2538,17 +2371,13 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
-            class A: NSObject {
+            class A {
             }
-            @objc
             class B: A {
-                @objc
                 override init(a: A) {
                     self = super.init(a: a)
                     return self
                 }
-                @objc
                 convenience init(b: B) {
                     self.init(a: a)
                 }
@@ -2569,9 +2398,7 @@ class SwiftRewriterTests: XCTestCase {
             @end
             """,
             swift: """
-            @objc
             class A: UIView {
-                @objc
                 override func convert(_ point: CGPoint, to view: UIView?) -> CGPoint {
                     return self.convert(CGPoint(x: 0, y: 0), to: nil)
                 }
@@ -2635,9 +2462,7 @@ class SwiftRewriterTests: XCTestCase {
             swift: """
             typealias callback = () -> Void
             
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 func doWork(_ call: callback?) {
                     call?()
                 }
@@ -2681,21 +2506,16 @@ class SwiftRewriterTests: XCTestCase {
             typealias predicate = (String?) -> Bool
             typealias other_predicate = (String?) -> Bool
             
-            @objc
-            class A: NSObject {
-                @objc
+            class A {
                 func doWork(_ call: callback?) {
                     call?()
                 }
-                @objc
                 func doMoreWork(_ predicate: predicate?) {
                     predicate?()
                 }
-                @objc
                 func doOtherWork(_ predicate: ((String) -> Bool)!) {
                     predicate?()
                 }
-                @objc
                 static func rawQuery(_ query: String, handler: (AnyObject?, Error?) -> Void) {
                     handler(nil, nil)
                 }

--- a/Tests/SwiftRewriterLibTests/SwiftRewriterTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriterTests.swift
@@ -851,7 +851,7 @@ class SwiftRewriterTests: XCTestCase {
                 func myMethod()
             }
             """,
-            options: ASTWriterOptions(omitObjcCompatibility: true))
+            options: ASTWriterOptions(emitObjcCompatibility: true))
     }
     
     func testRewriteProtocolConformance() {
@@ -1606,20 +1606,23 @@ class SwiftRewriterTests: XCTestCase {
                 case Enum_A
             }
             
-            protocol A {
+            @objc
+            protocol A: NSObjectProtocol {
                 var b: Bool { get set }
                 
                 func method()
             }
             
+            @objc
             class B: A {
-                var b: Bool = false
+                @objc var b: Bool = false
                 
+                @objc
                 func method() {
                 }
             }
             """,
-            options: ASTWriterOptions(omitObjcCompatibility: true))
+            options: ASTWriterOptions(emitObjcCompatibility: true))
     }
     
     /// Tests calls that override a super call by detection of a `super` call on

--- a/Tests/SwiftRewriterLibTests/SwiftWriterTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftWriterTests.swift
@@ -40,7 +40,6 @@ class SwiftWriterTests: XCTestCase {
         sut.outputInitMethod(initMethod, selfType: type, target: output.outputTarget())
         
         let expected = """
-            @objc
             init?() {
             }
             """
@@ -57,7 +56,6 @@ class SwiftWriterTests: XCTestCase {
         sut.outputInitMethod(initMethod, selfType: type, target: output.outputTarget())
         
         let expected = """
-            @objc
             convenience init() {
             }
             """


### PR DESCRIPTION
Can be turned on by using `--emit-objc-compatibility` in CLI.

`@objc`/`NSObjectProtocol` conformance is still emitted for protocols that contain optional requirements because they are an Objective-C-only feature.