### PR TITLE
Class interface parsing

### DIFF
--- a/Sources/SwiftAST/Ownership.swift
+++ b/Sources/SwiftAST/Ownership.swift
@@ -1,5 +1,5 @@
 /// Defines the ownership of a variable storage
-public enum Ownership: String, Equatable, Codable {
+public enum Ownership: String, Hashable, Codable {
     case strong
     case weak
     case unownedSafe = "unowned(safe)"

--- a/Sources/SwiftRewriterLib/AccessLevel.swift
+++ b/Sources/SwiftRewriterLib/AccessLevel.swift
@@ -4,6 +4,7 @@ public enum AccessLevel: String {
     case `fileprivate`
     case `internal`
     case `public`
+    case `open`
     
     /// Returns `true` if this access level value is of higher visibility than
     /// the one provided.
@@ -27,6 +28,12 @@ public enum AccessLevel: String {
         case (.public, .private),
              (.public, .fileprivate),
              (.public, .internal):
+            return true
+            
+        case (.open, .private),
+             (.open, .fileprivate),
+             (.open, .internal),
+             (.open, .public):
             return true
             
         default:

--- a/Sources/SwiftRewriterLib/Intentions/FromSourceIntention.swift
+++ b/Sources/SwiftRewriterLib/Intentions/FromSourceIntention.swift
@@ -45,8 +45,8 @@ public class FromSourceIntention: NonNullScopedIntention {
     /// intention, `false` otherwise.
     public func isVisible(for intention: FromSourceIntention) -> Bool {
         switch accessLevel {
-        // Internal/public are visible everywhere
-        case .public, .internal:
+        // Internal/public/open are visible everywhere
+        case .internal, .public, .open:
             return true
             
         case .fileprivate:

--- a/Sources/SwiftRewriterLib/KnownTypeBuilder.swift
+++ b/Sources/SwiftRewriterLib/KnownTypeBuilder.swift
@@ -80,6 +80,13 @@ public struct KnownTypeBuilder {
         self.useSwiftSignatureMatching = useSwiftSignatureMatching
     }
     
+    /// Changes the type name defined in this known type builder.
+    public func named(_ name: String) -> KnownTypeBuilder {
+        var new = clone()
+        new.type.typeName = name
+        return new
+    }
+    
     /// Sets the value of `useSwiftSignatureMatching` to be used for the remaining
     /// type builder invocations.
     public func settingUseSwiftSignatureMatching(_ value: Bool) -> KnownTypeBuilder {
@@ -478,6 +485,20 @@ public struct KnownTypeBuilder {
     }
 }
 
+// MARK: - Removal
+extension KnownTypeBuilder {
+    
+    /// Removes direct protocol conformances to protocols that match the given
+    /// name.
+    public func removingConformance(to protocolName: String) -> KnownTypeBuilder {
+        var new = clone()
+        new.type.protocols.removeAll(where: { $0.protocolName == protocolName })
+        return new
+    }
+    
+}
+
+// MARK: - Querying
 extension KnownTypeBuilder {
     /// Returns a reference to the latest constructor added to this `KnownTypeBuilder`
     /// via a `.constructor(...)` call
@@ -495,6 +516,11 @@ extension KnownTypeBuilder {
     /// via a `.property(...)` call
     public var lastProperty: KnownProperty? {
         return type.properties.last
+    }
+    
+    /// Returns the currently recorded protocol conformances for the final type
+    public var protocolConformances: [String] {
+        return type.protocols.map { $0.protocolName }
     }
 }
 

--- a/Sources/SwiftRewriterLib/KnownTypeBuilder.swift
+++ b/Sources/SwiftRewriterLib/KnownTypeBuilder.swift
@@ -550,6 +550,7 @@ private class DummyType: KnownType {
         knownProtocolConformances = type.knownProtocolConformances
         supertype = type.supertype
         semantics = type.semantics
+        isExtension = type.isExtension
     }
     
     init(typeName: String, supertype: KnownTypeReferenceConvertible? = nil) {

--- a/Sources/SwiftRewriterLib/SwiftClassInterfaceParser.swift
+++ b/Sources/SwiftRewriterLib/SwiftClassInterfaceParser.swift
@@ -252,9 +252,7 @@ public final class SwiftClassInterfaceParser {
     ///
     /// access-level-modifier
     ///     : 'public'
-    ///     | 'public(set)'
     ///     | 'open'
-    ///     | 'open(set)'
     ///     ;
     /// ```
     private static func parseDeclarationModifier(from tokenizer: Tokenizer) throws -> DeclarationModifier {

--- a/Sources/SwiftRewriterLib/SwiftClassInterfaceParser.swift
+++ b/Sources/SwiftRewriterLib/SwiftClassInterfaceParser.swift
@@ -1,0 +1,267 @@
+import SwiftAST
+import MiniLexer
+import Utils
+
+/// Provudes capabilities for parsing Swift class declarations.
+public final class SwiftClassInterfaceParser {
+    private typealias Tokenizer = TokenizerLexer<FullToken<Token>>
+    
+    /// Parses a class type interface signature from a given input string.
+    ///
+    /// String must contain a single, complete class or extension definition.
+    /// Definition must be interface-only (i.e. no method implementations or bodies).
+    public static func parseDefinition(from string: String) throws -> IncompleteKnownType {
+        
+        var builder = KnownTypeBuilder(typeName: "")
+        
+        try parseDefinition(from: string, into: &builder)
+        
+        return IncompleteKnownType(typeBuilder: builder)
+    }
+    
+    /// Parses a class type interface signature from a given input string into
+    /// a given know type builder object.
+    ///
+    /// String must contain a single, complete class or extension definition.
+    /// Definition must be interface-only (i.e. no method implementations or bodies).
+    public static func parseDefinition(from string: String,
+                                       into typeBuilder: inout KnownTypeBuilder) throws {
+        
+        let tokenizer = Tokenizer(input: string)
+        
+        var builder = typeBuilder
+        
+        builder = builder.named("")
+        
+        typeBuilder = builder
+    }
+    
+    /// ```
+    /// class-header
+    ///     : 'class' type-name (':' type-name (',' type-name)*)?
+    //          '{' class-body-definition '}'
+    ///     ;
+    ///
+    /// type-name
+    ///     : identifier
+    ///     ;
+    /// ```
+    private static func parseClassHeader(from tokenizer: Tokenizer,
+                                         _ typeBuilder: inout KnownTypeBuilder) throws {
+        
+        try tokenizer.advance(overTokenType: .class)
+        let name = try typeName(from: tokenizer)
+        var supertypes: [String] = []
+        
+        // Supertype/class conformances
+        // (':' type-name (',' type-name)*)?
+        if tokenizer.consumeToken(ifTypeIs: .colon) != nil {
+            let supertype = try typeName(from: tokenizer)
+            supertypes.append(supertype)
+            
+            // (',' type-name)*
+            _=tokenizer.lexer.performGreedyRounds { (lexer, _) in
+                guard tokenizer.consumeToken(ifTypeIs: .comma) != nil else {
+                    return false
+                }
+                
+                try supertypes.append(typeName(from: tokenizer))
+                
+                return true
+            }
+        }
+        
+        typeBuilder = typeBuilder
+            .named(name)
+            .protocolConformances(protocolNames: supertypes)
+    }
+    
+    private static func typeName(from tokenizer: Tokenizer) throws -> String {
+        do {
+            let token = try tokenizer.advance(overTokenType: .identifier)
+            
+            return String(token.value)
+        } catch {
+            throw tokenizer.lexer.syntaxError("Expected identifier")
+        }
+    }
+}
+
+public class IncompleteKnownType {
+    
+    private var knownTypeBuilder: KnownTypeBuilder
+    
+    fileprivate init(typeBuilder: KnownTypeBuilder) {
+        self.knownTypeBuilder = typeBuilder
+    }
+    
+    func complete(typeSystem: TypeSystem) -> KnownType {
+        
+        // We add all supertypes we find as protocol conformances since we can't
+        // verify during parsing that a type is either a protocol or a class, here
+        // we check for these protocol conformances to pick out which conformance
+        // is actually a supertype name, thus allowing us to complete the type
+        // properly.
+        for conformance in knownTypeBuilder.protocolConformances {
+            if typeSystem.isClassInstanceType(conformance) {
+                knownTypeBuilder = knownTypeBuilder
+                    .removingConformance(to: conformance)
+                    .settingSupertype(KnownTypeReference.typeName(conformance))
+                
+                break
+            }
+        }
+        
+        return knownTypeBuilder.build()
+    }
+}
+
+extension SwiftClassInterfaceParser {
+    
+    private enum Token: String, TokenProtocol {
+        private static let identifierLexer = (.letter | "_") + (.letter | "_" | .digit)*
+        
+        case openParens = "("
+        case closeParens = ")"
+        case colon = ":"
+        case comma = ","
+        case at = "@"
+        case underscore = "_"
+        case identifier
+        case functionArrow
+        case `var`
+        case `let`
+        case `func`
+        case `inout`
+        case `class`
+        case `throws`
+        case `static`
+        case `public`
+        case `private`
+        case `mutating`
+        case `rethrows`
+        case `internal`
+        case `extension`
+        case `fileprivate`
+        case eof
+        
+        func advance(in lexer: Lexer) throws {
+            let len = length(in: lexer)
+            guard len > 0 else {
+                throw LexerError.miscellaneous("Cannot advance")
+            }
+            
+            try lexer.advanceLength(len)
+        }
+        
+        func length(in lexer: Lexer) -> Int {
+            switch self {
+            case .openParens, .closeParens, .colon, .comma, .underscore, .at:
+                return 1
+            case .functionArrow:
+                return 2
+            case .var, .let:
+                return 3
+            case .func:
+                return 4
+            case .inout, .class:
+                return 5
+            case .throws, .public, .static:
+                return 6
+            case .private:
+                return 7
+            case .mutating, .rethrows, .internal:
+                return 8
+            case .extension:
+                return 9
+            case .fileprivate:
+                return 11
+            case .identifier:
+                return Token.identifierLexer.maximumLength(in: lexer) ?? 0
+            case .eof:
+                return 0
+            }
+        }
+        
+        var tokenString: String {
+            return rawValue
+        }
+        
+        static func tokenType(at lexer: Lexer) -> SwiftClassInterfaceParser.Token? {
+            if lexer.isEof() {
+                return .eof
+            }
+            
+            if lexer.safeIsNextChar(equalTo: "_") {
+                return lexer.withTemporaryIndex {
+                    try? lexer.advance()
+                    
+                    if lexer.safeNextCharPasses(with: { !Lexer.isLetter($0) && !Lexer.isDigit($0) && $0 != "_" }) {
+                        return .underscore
+                    }
+                    
+                    return .identifier
+                }
+            }
+            
+            if lexer.checkNext(matches: "->") {
+                return .functionArrow
+            }
+            
+            guard let next = try? lexer.peek() else {
+                return nil
+            }
+            
+            if Lexer.isLetter(next) {
+                guard let ident = try? lexer.withTemporaryIndex(changes: {
+                    try identifierLexer.consume(from: lexer)
+                }) else {
+                    return nil
+                }
+                
+                switch ident {
+                case "let":
+                    return .let
+                case "var":
+                    return .var
+                case "class":
+                    return .class
+                case "func":
+                    return .func
+                case "inout":
+                    return .inout
+                case "throws":
+                    return .throws
+                case "public":
+                    return .public
+                case "static":
+                    return .static
+                case "private":
+                    return .private
+                case "mutating":
+                    return .mutating
+                case "rethrows":
+                    return .rethrows
+                case "internal":
+                    return .internal
+                case "extension":
+                    return .extension
+                case "fileprivate":
+                    return .fileprivate
+                    
+                default:
+                    return .identifier
+                }
+            }
+            
+            if let token = Token(rawValue: String(next)) {
+                return token
+            }
+            
+            return nil
+        }
+        
+        static var eofToken: Token = .eof
+    }
+    
+}

--- a/Sources/SwiftRewriterLib/TypeFormatter.swift
+++ b/Sources/SwiftRewriterLib/TypeFormatter.swift
@@ -8,7 +8,11 @@ public enum TypeFormatter {
         
         let o = StringRewriterOutput(settings: .defaults)
         
-        o.outputInline("\(type.kind.rawValue) \(type.typeName)")
+        if type.isExtension {
+            o.outputInline("extension \(type.typeName)")
+        } else {
+            o.outputInline("\(type.kind.rawValue) \(type.typeName)")
+        }
         
         var inheritances: [String] = []
         

--- a/Tests/SwiftRewriterLibTests/SwiftClassInterfaceParserTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftClassInterfaceParserTests.swift
@@ -41,6 +41,18 @@ class SwiftClassInterfaceParserTests: XCTestCase {
         XCTAssertEqual(type.supertype?.asTypeName, "UIView")
     }
     
+    func testParseProtocolConformances() throws {
+        
+        let type = try parseType("""
+            class MyClass: A, B {
+            }
+            """)
+        
+        XCTAssertEqual(type.knownProtocolConformances.count, 2)
+        XCTAssertEqual(type.knownProtocolConformances[0].protocolName, "A")
+        XCTAssertEqual(type.knownProtocolConformances[1].protocolName, "B")
+    }
+    
     func testParseProperty() throws {
         
         let type = try parseType("""

--- a/Tests/SwiftRewriterLibTests/SwiftClassInterfaceParserTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftClassInterfaceParserTests.swift
@@ -1,0 +1,193 @@
+import XCTest
+import SwiftRewriterLib
+import SwiftAST
+import MiniLexer
+
+class SwiftClassInterfaceParserTests: XCTestCase {
+    
+    var typeSystem: DefaultTypeSystem!
+    
+    override func setUp() {
+        super.setUp()
+        
+        typeSystem = DefaultTypeSystem()
+    }
+    
+    func testParseEmptyClass() throws {
+        
+        let type = try parseType("""
+            class Empty {
+            }
+            """)
+        
+        XCTAssertEqual(type.typeName, "Empty")
+        XCTAssertEqual(type.knownProperties.count, 0)
+        XCTAssertEqual(type.knownMethods.count, 0)
+        XCTAssertEqual(type.knownConstructors.count, 0)
+        XCTAssertEqual(type.knownFields.count, 0)
+        XCTAssertEqual(type.knownProtocolConformances.count, 0)
+        XCTAssertFalse(type.isExtension)
+    }
+    
+    func testParseSupertypes() throws {
+        
+        let type = try parseType("""
+            class MyClass: UIView, B {
+            }
+            """)
+        
+        XCTAssertEqual(type.knownProtocolConformances.count, 1)
+        XCTAssertEqual(type.knownProtocolConformances[0].protocolName, "B")
+        XCTAssertEqual(type.supertype?.asTypeName, "UIView")
+    }
+    
+    func testParseProperty() throws {
+        
+        let type = try parseType("""
+            class MyClass {
+                var v1: Int
+                var v2: Int { get }
+                weak var v3: MyClass?
+            }
+            """)
+        
+        XCTAssertEqual(type.knownProperties.count, 3)
+        XCTAssertEqual(type.knownProperties[0].name, "v1")
+        XCTAssertEqual(type.knownProperties[0].storage.type, .int)
+        XCTAssertEqual(type.knownProperties[0].accessor, .getterAndSetter)
+        XCTAssertEqual(type.knownProperties[0].storage.ownership, .strong)
+        XCTAssertEqual(type.knownProperties[1].name, "v2")
+        XCTAssertEqual(type.knownProperties[1].storage.type, .int)
+        XCTAssertEqual(type.knownProperties[1].accessor, .getter)
+        XCTAssertEqual(type.knownProperties[1].storage.ownership, .strong)
+        XCTAssertEqual(type.knownProperties[2].name, "v3")
+        XCTAssertEqual(type.knownProperties[2].storage.type, .optional("MyClass"))
+        XCTAssertEqual(type.knownProperties[2].accessor, .getterAndSetter)
+        XCTAssertEqual(type.knownProperties[2].storage.ownership, .weak)
+    }
+    
+    func testParseFunction() throws {
+        
+        let type = try parseType("""
+            class MyClass {
+                func a()
+                func b(_ a: Int)
+                func c(a: String, b: Int?) -> MyClass
+            }
+            """)
+        
+        XCTAssertEqual(type.knownMethods.count, 3)
+        XCTAssertEqual(type.knownMethods[0].signature.name, "a")
+        XCTAssertEqual(type.knownMethods[0].signature.parameters.count, 0)
+        XCTAssertEqual(type.knownMethods[0].signature.returnType, .void)
+        
+        XCTAssertEqual(type.knownMethods[1].signature.name, "b")
+        XCTAssertEqual(type.knownMethods[1].signature.parameters.count, 1)
+        XCTAssertNil(type.knownMethods[1].signature.parameters[0].label)
+        XCTAssertEqual(type.knownMethods[1].signature.parameters[0].name, "a")
+        XCTAssertEqual(type.knownMethods[1].signature.parameters[0].type, .int)
+        XCTAssertEqual(type.knownMethods[1].signature.returnType, .void)
+        
+        XCTAssertEqual(type.knownMethods[2].signature.name, "c")
+        XCTAssertEqual(type.knownMethods[2].signature.parameters.count, 2)
+        XCTAssertEqual(type.knownMethods[2].signature.parameters[0].label, "a")
+        XCTAssertEqual(type.knownMethods[2].signature.parameters[0].name, "a")
+        XCTAssertEqual(type.knownMethods[2].signature.parameters[0].type, .string)
+        XCTAssertEqual(type.knownMethods[2].signature.parameters[1].label, "b")
+        XCTAssertEqual(type.knownMethods[2].signature.parameters[1].name, "b")
+        XCTAssertEqual(type.knownMethods[2].signature.parameters[1].type, .optional(.int))
+        XCTAssertEqual(type.knownMethods[2].signature.returnType, "MyClass")
+    }
+    
+    func testParseInitializer() throws {
+        
+        let type = try parseType("""
+            class MyClass {
+                init()
+            }
+            """)
+        
+        XCTAssertEqual(type.knownConstructors.count, 1)
+        XCTAssertEqual(type.knownConstructors[0].parameters.count, 0)
+    }
+    
+    func testBackToBackTypeParse() throws {
+        
+        let type = try parseType("""
+            class MyClass: UIView, UITableViewDelegate {
+                var count: Int { get }
+                var data: [String]
+                
+                init()
+                init(coder aDecoder: NSCoding)
+                
+                func a()
+                func b(_ a: Int)
+                func c(a: String, b: Int?) -> MyClass
+            }
+            """)
+        
+        let expected = """
+            class MyClass: UIView, UITableViewDelegate {
+                var count: Int { get }
+                var data: [String]
+                
+                init()
+                init(coder aDecoder: NSCoding)
+                func a()
+                func b(_ a: Int)
+                func c(a: String, b: Int?) -> MyClass
+            }
+            """
+        
+        let string = TypeFormatter.asString(knownType: type)
+        
+        XCTAssertEqual(
+            expected, string,
+            """
+            Expected to re-encode type as:
+            
+            \(expected)
+            
+            But re-encoded as:
+            
+            \(string)
+            
+            Diff:
+            
+            \(expected.makeDifferenceMarkString(against: string))
+            """
+        )
+    }
+}
+
+extension SwiftClassInterfaceParserTests {
+    
+    func parseType(_ string: String, file: String = #file, line: Int = #line) throws -> KnownType {
+        
+        do {
+            let type =
+                try SwiftClassInterfaceParser
+                    .parseDeclaration(from: string)
+            
+            return type.complete(typeSystem: typeSystem)
+        } catch {
+            
+            let description: String
+            if let error = error as? LexerError {
+                description = error.description(withOffsetsIn: string)
+            } else {
+                description = "\(error)"
+            }
+            
+            recordFailure(withDescription: "Error while parsing type: \(description)",
+                          inFile: file,
+                          atLine: line,
+                          expected: true)
+            
+            throw error
+        }
+        
+    }
+    
+}

--- a/Tests/SwiftRewriterLibTests/SwiftClassInterfaceParserTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftClassInterfaceParserTests.swift
@@ -111,6 +111,38 @@ class SwiftClassInterfaceParserTests: XCTestCase {
         XCTAssertEqual(type.knownConstructors[0].parameters.count, 0)
     }
     
+    func testParseExtensionDeclaration() throws {
+        let type = try parseType("""
+            extension MyClass {
+                func a()
+                func b(_ a: Int)
+                func c(a: String, b: Int?) -> MyClass
+            }
+            """)
+        
+        XCTAssertEqual(type.knownMethods.count, 3)
+        XCTAssertEqual(type.knownMethods[0].signature.name, "a")
+        XCTAssertEqual(type.knownMethods[0].signature.parameters.count, 0)
+        XCTAssertEqual(type.knownMethods[0].signature.returnType, .void)
+        
+        XCTAssertEqual(type.knownMethods[1].signature.name, "b")
+        XCTAssertEqual(type.knownMethods[1].signature.parameters.count, 1)
+        XCTAssertNil(type.knownMethods[1].signature.parameters[0].label)
+        XCTAssertEqual(type.knownMethods[1].signature.parameters[0].name, "a")
+        XCTAssertEqual(type.knownMethods[1].signature.parameters[0].type, .int)
+        XCTAssertEqual(type.knownMethods[1].signature.returnType, .void)
+        
+        XCTAssertEqual(type.knownMethods[2].signature.name, "c")
+        XCTAssertEqual(type.knownMethods[2].signature.parameters.count, 2)
+        XCTAssertEqual(type.knownMethods[2].signature.parameters[0].label, "a")
+        XCTAssertEqual(type.knownMethods[2].signature.parameters[0].name, "a")
+        XCTAssertEqual(type.knownMethods[2].signature.parameters[0].type, .string)
+        XCTAssertEqual(type.knownMethods[2].signature.parameters[1].label, "b")
+        XCTAssertEqual(type.knownMethods[2].signature.parameters[1].name, "b")
+        XCTAssertEqual(type.knownMethods[2].signature.parameters[1].type, .optional(.int))
+        XCTAssertEqual(type.knownMethods[2].signature.returnType, "MyClass")
+    }
+    
     func testBackToBackTypeParse() throws {
         
         let type = try parseType("""

--- a/Tests/SwiftRewriterLibTests/TypeFormatterTests.swift
+++ b/Tests/SwiftRewriterLibTests/TypeFormatterTests.swift
@@ -173,6 +173,22 @@ class TypeFormatterTests: XCTestCase {
         XCTAssertEqual(result, expected, "\n" + result.makeDifferenceMarkString(against: expected))
     }
     
+    func testAsStringKnownTypeExtension() {
+        let type = KnownTypeBuilder(typeName: "A", kind: .class)
+            .settingIsExtension(true)
+            .property(named: "a", type: .int)
+            .build()
+        
+        let result = TypeFormatter.asString(knownType: type)
+        let expected = """
+            extension A {
+                var a: Int
+            }
+            """
+        
+        XCTAssertEqual(result, expected, "\n" + result.makeDifferenceMarkString(against: expected))
+    }
+    
     func testAsStringKnownTypeEnum() {
         let type = KnownTypeBuilder(typeName: "A", kind: .enum)
             .enumRawValue(type: .int)


### PR DESCRIPTION
Adds support for parsing full `class`/`extension` declarations (in interface form).

After that's implemented, it will be favored over writing compound type definitions by hand using type builders.