### PR TITLE
Support for postfix force unwrap

### DIFF
--- a/Sources/ExpressionPasses/ASTCorrectorExpressionPass.swift
+++ b/Sources/ExpressionPasses/ASTCorrectorExpressionPass.swift
@@ -240,7 +240,7 @@ public class ASTCorrectorExpressionPass: ASTRewriterPass {
                             .binary(op: .nullCoalesce, rhs: initValue)
                     ).typed(memberType.deepUnwrapped)
             
-            res = Expression.postfix(res, memberPostfix.op.copy().withOptionalAccess(enabled: false))
+            res = Expression.postfix(res, memberPostfix.op.copy().withOptionalAccess(kind: .none))
             
             res.resolvedType = memberPostfix.resolvedType
             

--- a/Sources/ExpressionPasses/ASTSimplifier.swift
+++ b/Sources/ExpressionPasses/ASTSimplifier.swift
@@ -54,7 +54,7 @@ public class ASTSimplifier: ASTRewriterPass {
                             ))
         
         if matcher.matches(stmt), let postfix = postfix?.copy() {
-            postfix.op.hasOptionalAccess = true
+            postfix.op.optionalAccessKind = .safeUnwrap
             
             let statement = Statement.expression(postfix)
             

--- a/Sources/ExpressionPasses/AllocInitExpressionPass.swift
+++ b/Sources/ExpressionPasses/AllocInitExpressionPass.swift
@@ -105,7 +105,7 @@ public class AllocInitExpressionPass: ASTRewriterPass {
         
         let newArgs = swiftify(methodName: initName, arguments: args)
         
-        if initTarget.op.hasOptionalAccess {
+        if initTarget.op.optionalAccessKind != .none {
             return target.optional().dot("init").call(newArgs)
         }
         

--- a/Sources/ExpressionPasses/FoundationExpressionPass.swift
+++ b/Sources/ExpressionPasses/FoundationExpressionPass.swift
@@ -91,9 +91,10 @@ public class FoundationExpressionPass: BaseExpressionPass {
             FunctionArgument.labeled("to", fc.arguments[0].expression)
         ])
         
-        if postfix.op.hasOptionalAccess {
+        if postfix.op.optionalAccessKind != .none {
+            let accessKind = postfix.op.optionalAccessKind
             postfix.op = .member("responds")
-            postfix.op.hasOptionalAccess = true
+            postfix.op.optionalAccessKind = accessKind
             exp.resolvedType = .optional(.bool)
         } else {
             postfix.op = .member("responds")
@@ -165,8 +166,10 @@ public class FoundationExpressionPass: BaseExpressionPass {
         newExp.exp = .postfix(postfix.exp.copy(), .member("addObjects"))
         newExp.resolvedType = .void
         
-        if postfix.op.hasOptionalAccess {
-            newExp.exp.asPostfix?.member?.hasOptionalAccess = true
+        let postfixOptional = postfix.op.optionalAccessKind
+        if postfixOptional != .none {
+            newExp.exp.asPostfix?.member?.optionalAccessKind = postfixOptional
+            
             newExp.resolvedType = .optional(.void)
         }
         

--- a/Sources/ExpressionPasses/NilValueTransformationsPass.swift
+++ b/Sources/ExpressionPasses/NilValueTransformationsPass.swift
@@ -64,11 +64,11 @@ public class NilValueTransformationsPass: ASTRewriterPass {
                 continue
             }
             
-            if type.isOptional && !type.canBeImplicitlyUnwrapped && !postfix.hasOptionalAccess {
-                postfix.hasOptionalAccess = true
+            if type.isOptional && !type.canBeImplicitlyUnwrapped && postfix.optionalAccessKind == .none {
+                postfix.optionalAccessKind = .safeUnwrap
                 notifyChange()
-            } else if !type.isOptional && postfix.hasOptionalAccess {
-                postfix.hasOptionalAccess = false
+            } else if !type.isOptional && postfix.optionalAccessKind != .none {
+                postfix.optionalAccessKind = .none
                 notifyChange()
             }
         }
@@ -83,7 +83,7 @@ public class NilValueTransformationsPass: ASTRewriterPass {
         
         // Function call
         if exp.op is FunctionCallPostfix {
-            exp.op.hasOptionalAccess = true
+            exp.op.optionalAccessKind = .safeUnwrap
             
             return exp
         }

--- a/Sources/ExpressionPasses/UIKitExpressionPass.swift
+++ b/Sources/ExpressionPasses/UIKitExpressionPass.swift
@@ -95,7 +95,7 @@ public class UIKitExpressionPass: BaseExpressionPass {
         }
         
         let op = Postfix.member(converted)
-        op.hasOptionalAccess = exp.op.hasOptionalAccess
+        op.optionalAccessKind = exp.op.optionalAccessKind
         
         exp.op = op
         

--- a/Sources/SwiftAST/Expression+Ext.swift
+++ b/Sources/SwiftAST/Expression+Ext.swift
@@ -121,17 +121,18 @@ extension Expression: ExpressionPostfixBuildable {
     
     /// Begins an optional postfix creation from this expression.
     public func optional() -> OptionalAccessPostfixBuilder {
-        return OptionalAccessPostfixBuilder(exp: self)
+        return OptionalAccessPostfixBuilder(exp: self, isForceUnwrap: false)
     }
 }
 
 public struct OptionalAccessPostfixBuilder: ExpressionPostfixBuildable {
     public var exp: Expression
+    public var isForceUnwrap: Bool
     
     public var expressionToBuild: Expression { return exp }
     
     public func copy() -> OptionalAccessPostfixBuilder {
-        return OptionalAccessPostfixBuilder(exp: exp.copy())
+        return OptionalAccessPostfixBuilder(exp: exp.copy(), isForceUnwrap: isForceUnwrap)
     }
     
     public func call(_ arguments: [FunctionArgument],
@@ -141,7 +142,7 @@ public struct OptionalAccessPostfixBuilder: ExpressionPostfixBuildable {
         let op = Postfix.functionCall(arguments: arguments)
         op.returnType = type
         op.callableSignature = callableSignature
-        op.hasOptionalAccess = true
+        op.optionalAccessKind = isForceUnwrap ? .forceUnwrap : .safeUnwrap
         
         return .postfix(expressionToBuild, op)
     }
@@ -153,7 +154,7 @@ public struct OptionalAccessPostfixBuilder: ExpressionPostfixBuildable {
         let op = Postfix.functionCall(arguments: unlabeledArguments.map(FunctionArgument.unlabeled))
         op.returnType = type
         op.callableSignature = callableSignature
-        op.hasOptionalAccess = true
+        op.optionalAccessKind = isForceUnwrap ? .forceUnwrap : .safeUnwrap
         
         return .postfix(expressionToBuild, op)
     }
@@ -161,7 +162,7 @@ public struct OptionalAccessPostfixBuilder: ExpressionPostfixBuildable {
     public func dot(_ member: String, type: SwiftType?) -> PostfixExpression {
         let op = Postfix.member(member)
         op.returnType = type
-        op.hasOptionalAccess = true
+        op.optionalAccessKind = isForceUnwrap ? .forceUnwrap : .safeUnwrap
         
         return .postfix(expressionToBuild, op)
     }
@@ -169,7 +170,7 @@ public struct OptionalAccessPostfixBuilder: ExpressionPostfixBuildable {
     public func sub(_ exp: Expression, type: SwiftType?) -> PostfixExpression {
         let op = Postfix.subscript(exp)
         op.returnType = type
-        op.hasOptionalAccess = true
+        op.optionalAccessKind = isForceUnwrap ? .forceUnwrap : .safeUnwrap
         
         return .postfix(expressionToBuild, op)
     }

--- a/Sources/SwiftAST/Expression+Ext.swift
+++ b/Sources/SwiftAST/Expression+Ext.swift
@@ -123,6 +123,11 @@ extension Expression: ExpressionPostfixBuildable {
     public func optional() -> OptionalAccessPostfixBuilder {
         return OptionalAccessPostfixBuilder(exp: self, isForceUnwrap: false)
     }
+    
+    /// Begins a force-unwrap optional postfix creation from this expression.
+    public func forceUnwrap() -> OptionalAccessPostfixBuilder {
+        return OptionalAccessPostfixBuilder(exp: self, isForceUnwrap: true)
+    }
 }
 
 public struct OptionalAccessPostfixBuilder: ExpressionPostfixBuildable {

--- a/Sources/SwiftAST/SyntaxNodeRewriter.swift
+++ b/Sources/SwiftAST/SyntaxNodeRewriter.swift
@@ -75,7 +75,10 @@ open class SyntaxNodeRewriter: ExpressionVisitor, StatementVisitor {
     open func visitPostfix(_ exp: PostfixExpression) -> Expression {
         exp.exp = visitExpression(exp.exp)
         
-        let wasOptional = exp.op.hasOptionalAccess
+        // TODO: Maybe there's no need to manually save optionality access here
+        // anymore because `Postfix` subtypes already implement that in their
+        // respective `replacing-` methods.
+        let originalAccess = exp.op.optionalAccessKind
         
         switch exp.op {
         case let fc as FunctionCallPostfix:
@@ -88,7 +91,7 @@ open class SyntaxNodeRewriter: ExpressionVisitor, StatementVisitor {
             break
         }
         
-        exp.op.hasOptionalAccess = wasOptional
+        exp.op.optionalAccessKind = originalAccess
         
         return exp
     }

--- a/Sources/SwiftRewriterLib/MandatorySyntaxNodePass.swift
+++ b/Sources/SwiftRewriterLib/MandatorySyntaxNodePass.swift
@@ -15,7 +15,7 @@ class MandatorySyntaxNodePass: ASTRewriterPass {
     override func visitPostfix(_ exp: PostfixExpression) -> Expression {
         // Optionalize access to casted value's members
         if exp.exp.unwrappingParens.asCast?.isOptionalCast == true {
-            exp.op.hasOptionalAccess = true
+            exp.op.optionalAccessKind = .safeUnwrap
         }
         
         // [Type new]

--- a/Sources/SwiftRewriterLib/SwiftASTWriter.swift
+++ b/Sources/SwiftRewriterLib/SwiftASTWriter.swift
@@ -185,7 +185,12 @@ internal class ExpressionWriter: ExpressionVisitor {
     func visitPostfix(_ exp: PostfixExpression) {
         visitExpression(exp.exp, parens: exp.exp.requiresParens)
         
-        if exp.op.hasOptionalAccess {
+        switch exp.op.optionalAccessKind {
+        case .none:
+            break
+        case .forceUnwrap:
+            target.outputInline("!")
+        case .safeUnwrap:
             target.outputInline("?")
         }
         

--- a/Sources/SwiftRewriterLib/TypeResolution/ExpressionTypeResolver.swift
+++ b/Sources/SwiftRewriterLib/TypeResolution/ExpressionTypeResolver.swift
@@ -463,7 +463,7 @@ public final class ExpressionTypeResolver: SyntaxNodeRewriter {
                 return true
             }
             
-            if op.hasOptionalAccess {
+            if op.optionalAccessKind != .none {
                 return true
             }
             
@@ -686,7 +686,7 @@ private class MemberInvocationResolver {
     func resolve(postfix exp: PostfixExpression, op: Postfix) -> Expression {
         defer {
             // Elevate an implicitly-unwrapped optional access to an optional access
-            if exp.op.hasOptionalAccess {
+            if exp.op.optionalAccessKind != .none {
                 
                 switch exp.resolvedType {
                 case .implicitUnwrappedOptional(let inner)?,

--- a/Tests/SwiftASTTests/ExpressionTests.swift
+++ b/Tests/SwiftASTTests/ExpressionTests.swift
@@ -63,6 +63,10 @@ class ExpressionTests: XCTestCase {
             Expression.identifier("abc").casted(to: .string).optional().dot("count").description,
             "(abc as? String)?.count"
         )
+        XCTAssertEqual(
+            Expression.identifier("abc").casted(to: .string).forceUnwrap().dot("count").description,
+            "(abc as? String)!.count"
+        )
     }
     
     func testDescriptionBinaryOps() {

--- a/Tests/SwiftASTTests/SyntaxNodeRewriterTests.swift
+++ b/Tests/SwiftASTTests/SyntaxNodeRewriterTests.swift
@@ -47,7 +47,7 @@ class SyntaxNodeRewriterTests: XCTestCase {
         
         let result = sut.visitExpression(makeNode())
         
-        XCTAssert(result.asPostfix?.op.hasOptionalAccess == true)
+        XCTAssertEqual(result.asPostfix?.op.optionalAccessKind, .safeUnwrap)
         XCTAssertEqual(result.asPostfix?.functionCall?.returnType, .int)
         XCTAssertEqual(result.asPostfix?.functionCall?.callableSignature,
                        .swiftBlock(returnType: .int, parameters: [.typeName("b")]))
@@ -64,7 +64,7 @@ class SyntaxNodeRewriterTests: XCTestCase {
         let result = sut.visitExpression(makeNode())
         
         XCTAssertEqual(result.asPostfix?.subscription?.returnType, .int)
-        XCTAssert(result.asPostfix?.op.hasOptionalAccess == true)
+        XCTAssertEqual(result.asPostfix?.op.optionalAccessKind, .safeUnwrap)
     }
     
     /// Tests Postfix.returnType metadata information is kept when traversing a
@@ -78,6 +78,6 @@ class SyntaxNodeRewriterTests: XCTestCase {
         let result = sut.visitExpression(makeNode())
         
         XCTAssertEqual(result.asPostfix?.member?.returnType, .int)
-        XCTAssert(result.asPostfix?.op.hasOptionalAccess == true)
+        XCTAssertEqual(result.asPostfix?.op.optionalAccessKind, .safeUnwrap)
     }
 }


### PR DESCRIPTION
I.e. `foo!.member`; we currently support `foo?.member`, already.

Also taking the opportunity to split Expression and Statement nodes into separate files, since they are getting quite bulky.