### PR TITLE
Refactorings to switch statement handling

### DIFF
--- a/Sources/Commons/IncompleteKnownType+CompoundType.swift
+++ b/Sources/Commons/IncompleteKnownType+CompoundType.swift
@@ -126,7 +126,7 @@ private func initTransformations(_ ctor: KnownConstructor, type: KnownType) thro
             
         case .renameFrom, .mapToBinaryOperator:
             // TODO: Throw diagnostic error for unsupported mappings
-             break
+            break
         }
     }
     

--- a/Sources/Commons/IncompleteKnownType+CompoundType.swift
+++ b/Sources/Commons/IncompleteKnownType+CompoundType.swift
@@ -126,7 +126,7 @@ private func initTransformations(_ ctor: KnownConstructor, type: KnownType) thro
             
         case .renameFrom, .mapToBinaryOperator:
             // TODO: Throw diagnostic error for unsupported mappings
-            break
+             break
         }
     }
     

--- a/Sources/ExpressionPasses/ASTSimplifier.swift
+++ b/Sources/ExpressionPasses/ASTSimplifier.swift
@@ -65,6 +65,26 @@ public class ASTSimplifier: ASTRewriterPass {
         
         return super.visitIf(stmt)
     }
+    
+    /// Simplify switch statements by removing spurious `break` statements from
+    /// cases
+    public override func visitSwitch(_ stmt: SwitchStatement) -> Statement {
+        for (i, cs) in stmt.cases.enumerated() {
+            if cs.statements.count > 1 && cs.statements.last is BreakStatement {
+                stmt.cases[i].statements.removeLast()
+                notifyChange()
+            }
+        }
+        
+        if let def = stmt.defaultCase {
+            if def.count > 1 && def.last is BreakStatement {
+                stmt.defaultCase?.removeLast()
+                notifyChange()
+            }
+        }
+
+        return super.visitSwitch(stmt)
+    }
 }
 
 extension IfStatement {

--- a/Sources/SwiftAST/AnonymousSyntaxNodeVisitor.swift
+++ b/Sources/SwiftAST/AnonymousSyntaxNodeVisitor.swift
@@ -300,7 +300,14 @@ public final class AnonymousSyntaxNodeVisitor: ExpressionVisitor, StatementVisit
     public func visitBreak(_ stmt: BreakStatement) {
         listener(stmt)
     }
-    
+
+    /// Visits a fallthrough statement
+    ///
+    /// - Parameter stmt: A FallthroughStatement to visit
+    public func visitFallthrough(_ stmt: FallthroughStatement) {
+        listener(stmt)
+    }
+
     /// Visits a continue statement
     ///
     /// - Parameter stmt: A ContinueStatement to visit

--- a/Sources/SwiftAST/Statement.swift
+++ b/Sources/SwiftAST/Statement.swift
@@ -91,6 +91,9 @@ public extension Statement {
     public static var `break`: BreakStatement {
         return BreakStatement()
     }
+    public static var `fallthrough`: FallthroughStatement {
+        return FallthroughStatement()
+    }
     public static var `continue`: ContinueStatement {
         return ContinueStatement()
     }

--- a/Sources/SwiftAST/Statement/FallthroughStatement.swift
+++ b/Sources/SwiftAST/Statement/FallthroughStatement.swift
@@ -1,0 +1,22 @@
+public class FallthroughStatement: Statement {
+    public override var isUnconditionalJump: Bool {
+        return true
+    }
+
+    public override func copy() -> FallthroughStatement {
+        return FallthroughStatement().copyMetadata(from: self)
+    }
+
+    public override func accept<V: StatementVisitor>(_ visitor: V) -> V.StmtResult {
+        return visitor.visitFallthrough(self)
+    }
+
+    public override func isEqual(to other: Statement) -> Bool {
+        return other is FallthroughStatement
+    }
+}
+public extension Statement {
+    public var asFallthrough: FallthroughStatement? {
+        return cast()
+    }
+}

--- a/Sources/SwiftAST/StatementVisitor.swift
+++ b/Sources/SwiftAST/StatementVisitor.swift
@@ -73,7 +73,13 @@ public protocol StatementVisitor {
     /// - Parameter stmt: A break statement to visit
     /// - Returns: Result of visiting the break statement
     func visitBreak(_ stmt: BreakStatement) -> StmtResult
-    
+
+    /// Visits a fallthrough statement
+    ///
+    /// - Parameter stmt: A fallthrough statement to visit
+    /// - Returns: Result of visiting the fallthrough statement
+    func visitFallthrough(_ stmt: FallthroughStatement) -> StmtResult
+
     /// Visits a continue statement
     ///
     /// - Parameter stmt: A continue statement to visit

--- a/Sources/SwiftAST/SyntaxNodeRewriter.swift
+++ b/Sources/SwiftAST/SyntaxNodeRewriter.swift
@@ -327,7 +327,15 @@ open class SyntaxNodeRewriter: ExpressionVisitor, StatementVisitor {
     open func visitBreak(_ stmt: BreakStatement) -> Statement {
         return stmt
     }
-    
+
+    /// Visits a fallthrough statement
+    ///
+    /// - Parameter stmt: A FallthroughStatement to visit
+    /// - Returns: Result of visiting the fallthrough statement
+    open func visitFallthrough(_ stmt: FallthroughStatement) -> Statement {
+        return stmt
+    }
+
     /// Visits a continue statement
     ///
     /// - Parameter stmt: A ContinueStatement to visit

--- a/Sources/SwiftRewriterLib/SwiftASTWriter.swift
+++ b/Sources/SwiftRewriterLib/SwiftASTWriter.swift
@@ -518,21 +518,8 @@ internal class StatementWriter: StatementVisitor {
             target.outputLineFeed()
             
             target.idented {
-                // TODO: Abstract these omit-break/fallthrough-inserting behaviors
-                // to an external ASTRewriterPass
-                for (i, stmt) in cs.statements.enumerated() {
-                    // No need to emit the last break statement (if it's not the
-                    // only statement)
-                    if i > 0 && i == cs.statements.count - 1 && stmt == .break {
-                        break
-                    }
-                    
+                for stmt in cs.statements {
                     visitStatement(stmt)
-                }
-                
-                let hasBreak = cs.statements.last?.isUnconditionalJump ?? false
-                if !hasBreak {
-                    target.output(line: "fallthrough", style: .keyword)
                 }
             }
         }
@@ -544,15 +531,7 @@ internal class StatementWriter: StatementVisitor {
             target.outputLineFeed()
             
             target.idented {
-                // TODO: Abstract this omit-break behavior to an external
-                // ASTRewriterPass
-                for (i, stmt) in def.enumerated() {
-                    // No need to emit the last break statement (if it's not the
-                    // only statement)
-                    if i > 0 && i == def.count - 1 && stmt == .break {
-                        break
-                    }
-                    
+                for stmt in def {
                     visitStatement(stmt)
                 }
             }
@@ -613,6 +592,10 @@ internal class StatementWriter: StatementVisitor {
     
     func visitBreak(_ stmt: BreakStatement) {
         target.output(line: "break", style: .keyword)
+    }
+
+    func visitFallthrough(_ stmt: FallthroughStatement) {
+        target.output(line: "fallthrough", style: .keyword)
     }
     
     func visitExpressions(_ stmt: ExpressionsStatement) {

--- a/Sources/SwiftRewriterLib/SwiftStatementASTReader.swift
+++ b/Sources/SwiftRewriterLib/SwiftStatementASTReader.swift
@@ -227,6 +227,14 @@ public final class SwiftStatementASTReader: ObjectiveCParserBaseVisitor<Statemen
                     statements = stmt.statements
                 }
                 
+                // Append a default fallthrough, in case the last statement is
+                // not a jump stmt to somewhere else (`return`, `continue` or
+                // `break`)
+                let hasBreak = statements.last?.isUnconditionalJump ?? false
+                if !hasBreak {
+                    statements.append(.fallthrough)
+                }
+                
                 let labels = section.switchLabel()
                 // Default case
                 if labels.contains(where: { $0.rangeExpression() == nil }) {
@@ -248,8 +256,8 @@ public final class SwiftStatementASTReader: ObjectiveCParserBaseVisitor<Statemen
             }
         }
         
-        // Always emit a default break statement, since switches in Swift must
-        // be exhaustive
+        // If no default is present, always emit a `default: break` statement,
+        // since switches in Swift must be exhaustive
         if def == nil {
             def = [.break]
         }

--- a/Tests/ExpressionPassesTests/ASTSimplifierTests.swift
+++ b/Tests/ExpressionPassesTests/ASTSimplifierTests.swift
@@ -244,4 +244,64 @@ class ASTSimplifierTests: ExpressionPassTestCase {
             into: Expression.parens(.constant(0)).binary(op: .add, rhs: .constant(1))
         ); assertDidNotNotifyChange()
     }
+    
+    /// Tests that spurious break statements as the last statement of a switch
+    /// case are removed (since in Swift switches automatically break at the end
+    /// of a case)
+    func testSimplifyBreakAsLastSwitchCaseStatement() {
+        assertTransform(
+            statement: Statement
+                .switch(
+                    .constant(0),
+                    cases: [
+                        SwitchCase(patterns: [], statements: [
+                            Statement.expression(.identifier("stmt")),
+                            Statement.break
+                        ])
+                    ],
+                    default: [
+                        Statement.expression(.identifier("stmt")),
+                        Statement.break
+                    ]),
+            into: Statement
+                .switch(
+                    .constant(0),
+                    cases: [
+                        SwitchCase(patterns: [], statements: [
+                            Statement.expression(.identifier("stmt")),
+                        ])
+                    ],
+                    default: [
+                        Statement.expression(.identifier("stmt")),
+                    ])
+        ); assertNotifiedChange()
+    }
+    
+    /// Asserts that we don't remove break statements from empty switch cases
+    func testDontRemoveBreakFromEmptyCases() {
+        assertTransform(
+            statement: Statement
+                .switch(
+                    .constant(0),
+                    cases: [
+                        SwitchCase(patterns: [], statements: [
+                            Statement.break
+                        ])
+                    ],
+                    default: [
+                        Statement.break
+                    ]),
+            into: Statement
+                .switch(
+                    .constant(0),
+                    cases: [
+                        SwitchCase(patterns: [], statements: [
+                            Statement.break
+                        ])
+                    ],
+                    default: [
+                        Statement.break
+                    ])
+        ); assertDidNotNotifyChange()
+    }
 }

--- a/Tests/ExpressionPassesTests/ExpressionPassTestCase.swift
+++ b/Tests/ExpressionPassesTests/ExpressionPassTestCase.swift
@@ -146,7 +146,7 @@ class ExpressionPassTestCase: XCTestCase {
                                 typeSystem: DefaultTypeSystem())
             
             prettyPrintExpWriter.visitStatement(expected)
-            prettyPrintResWriter.visitStatement(statement)
+            prettyPrintResWriter.visitStatement(result)
             
             dump(expected, to: &expString)
             dump(result, to: &resString)
@@ -244,8 +244,6 @@ class ExpressionPassTestCase: XCTestCase {
         let block: () -> Void = { [weak self] in
             self?.notified = true
         }
-        
-        
         
         return ASTRewriterPassContext(typeSystem: typeSystem,
                                       notifyChangedTree: block,

--- a/Tests/SwiftASTTests/SyntaxNodeIteratorTests.swift
+++ b/Tests/SwiftASTTests/SyntaxNodeIteratorTests.swift
@@ -322,7 +322,7 @@ class SyntaxNodeIteratorTests: XCTestCase {
                        L. case -> patterns
                    2.           |    L. pattern -> expression(s)
                    3.  L. case -> statement(s)
-                   4.            L. statement(s)
+                   4.  L. default ->  statement(s)
      
      1. Switch expression
      2. Switch cases' patterns
@@ -444,6 +444,10 @@ class SyntaxNodeIteratorTests: XCTestCase {
     
     func testContinue() {
         assertStatement(.continue, iteratesAs: [Statement.continue])
+    }
+    
+    func testFallthourh() {
+        assertStatement(.fallthrough, iteratesAs: [Statement.fallthrough])
     }
     
     func testVariableDeclarationsNotInspectingBlocks() {

--- a/Tests/SwiftRewriterLibTests/SwiftStatementASTReaderTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftStatementASTReaderTests.swift
@@ -225,6 +225,21 @@ class SwiftStatementASTReaderTests: XCTestCase {
         )
     }
     
+    func testAutomaticSwitchFallthrough() {
+        assert(objcStmt: "switch(value) { case 0: stmt(); case 1: break; }",
+               readsAs: .switch(.identifier("value"),
+                                cases: [
+                                    SwitchCase(patterns: [.expression(.constant(0))],
+                                               statements: [
+                                                .expression(Expression.identifier("stmt").call()),
+                                                .fallthrough
+                                                ]),
+                                    SwitchCase(patterns: [.expression(.constant(1))], statements: [.break])
+                                ],
+                                default: [.break])
+        )
+    }
+    
     func testExpressions() {
         assert(objcStmt: "abc;",
                readsAs: .expression(.identifier("abc"))


### PR DESCRIPTION
Mainly move some code that was inherent to `SwiftASTWriter` into `ASTSimplifier` (removal of spurious `break` statements) and `SwiftStatementASTReader` (emitting fallthrough at end of non-terminated cases)