### PR TITLE
Nullability analysis of local variables

### DIFF
--- a/Sources/ExpressionPasses/DefaultExpressionPasses.swift
+++ b/Sources/ExpressionPasses/DefaultExpressionPasses.swift
@@ -17,6 +17,7 @@ public class DefaultExpressionPasses: ASTRewriterPassSource {
         NumberCommonsExpressionPass.self,
         EnumRewriterExpressionPass.self,
         LocalConstantPromotionExpressionPass.self,
+        VariableNullabilityPromotionExpressionPass.self,
         // Do a last simplification pass after all other passes
         ASTSimplifier.self
     ]

--- a/Sources/ExpressionPasses/VariableNullabilityPromotionExpressionPass.swift
+++ b/Sources/ExpressionPasses/VariableNullabilityPromotionExpressionPass.swift
@@ -39,7 +39,10 @@ public class VariableNullabilityPromotionExpressionPass: ASTRewriterPass {
             if decl.initialization == nil && decl.isConstant {
                 continue
             }
-            if usages.isEmpty, let initialization = decl.initialization {
+            if decl.initialization?.isErrorTyped == true {
+                continue
+            }
+            if let initialization = decl.initialization {
                 if initialization.literalExpressionKind == .nil || initialization.resolvedType?.isOptional == true {
                     continue
                 }

--- a/Sources/ExpressionPasses/VariableNullabilityPromotionExpressionPass.swift
+++ b/Sources/ExpressionPasses/VariableNullabilityPromotionExpressionPass.swift
@@ -1,0 +1,69 @@
+import Foundation
+import SwiftRewriterLib
+import SwiftAST
+import Utils
+
+/// Promotes local variables in method bodies to non-nil if all assignment sites
+/// are detected to be non-nil as well.
+public class VariableNullabilityPromotionExpressionPass: ASTRewriterPass {
+    let localsAnalyzer: LocalsUsageAnalyzer?
+    
+    public required init(context: ASTRewriterPassContext) {
+        if let body = context.functionBodyIntention {
+            localsAnalyzer =
+                LocalUsageAnalyzer(functionBody: body,
+                                   typeSystem: context.typeSystem)
+        } else {
+            localsAnalyzer = nil
+        }
+        
+        super.init(context: context)
+    }
+    
+    public override func visitVariableDeclarations(_ stmt: VariableDeclarationsStatement) -> Statement {
+        let stmt = super.visitVariableDeclarations(stmt)
+        
+        guard let localsAnalyzer = localsAnalyzer else {
+            return stmt
+        }
+        guard let varDeclStmt = stmt.asVariableDeclaration else {
+            return stmt
+        }
+        
+        for (i, decl) in varDeclStmt.decl.enumerated() {
+            let usages = localsAnalyzer.findUsagesOf(localNamed: decl.identifier)
+            
+            if usages.isEmpty && decl.initialization == nil {
+                continue
+            }
+            if decl.initialization == nil && decl.isConstant {
+                continue
+            }
+            if usages.isEmpty, let initialization = decl.initialization {
+                if initialization.literalExpressionKind == .nil || initialization.resolvedType?.isOptional == true {
+                    continue
+                }
+            }
+            
+            var isNilSet = false
+            
+            for usage in usages where !usage.isReadOnlyUsage {
+                guard let assignExp = usage.expression.parentExpression?.asAssignment else {
+                    continue
+                }
+                
+                if assignExp.rhs.literalExpressionKind == .nil || assignExp.rhs.resolvedType?.isOptional == true {
+                    isNilSet = true
+                    break
+                }
+            }
+            
+            if !isNilSet {
+                varDeclStmt.decl[i].type = varDeclStmt.decl[i].type.deepUnwrapped
+                notifyChange()
+            }
+        }
+        
+        return varDeclStmt
+    }
+}

--- a/Sources/SwiftRewriterLib/SwiftASTWriter.swift
+++ b/Sources/SwiftRewriterLib/SwiftASTWriter.swift
@@ -628,19 +628,7 @@ internal class StatementWriter: StatementVisitor {
             
             // (Optional) Type signature
             if shouldEmitType {
-                let declarationType: SwiftType
-                
-                if declaration.initialization?.isErrorTyped == false, let initType = declaration.initialization?.resolvedType {
-                    if typeSystem.isType(initType.deepUnwrapped, assignableTo: declaration.type.deepUnwrapped) {
-                        declarationType = declaration.type.withSameOptionalityAs(initType)
-                    } else {
-                        declarationType = declaration.type
-                    }
-                } else {
-                    declarationType = declaration.type
-                }
-                
-                let typeString = typeMapper.typeNameString(for: declarationType)
+                let typeString = typeMapper.typeNameString(for: declaration.type)
                 target.outputInline(": ")
                 target.outputInline(typeString, style: .typeName)
             }
@@ -780,6 +768,10 @@ internal class StatementWriter: StatementVisitor {
             
             if isConstant {
                 return false
+            }
+            
+            if type.isOptional != varType.isOptional {
+                return true
             }
             
             return !typeSystem.typesMatch(type, varType, ignoreNullability: true)

--- a/Sources/SwiftRewriterLib/UsageAnalysis.swift
+++ b/Sources/SwiftRewriterLib/UsageAnalysis.swift
@@ -12,7 +12,7 @@ public protocol UsageAnalyzer {
 /// A refined usage analyzer capable of inspecting usages of local variables by
 /// name within a method body.
 public protocol LocalsUsageAnalyzer: UsageAnalyzer {
-    func findUsagesOf(local: String) -> [DefinitionUsage]
+    func findUsagesOf(localNamed: String) -> [DefinitionUsage]
 }
 
 public class BaseUsageAnalyzer: UsageAnalyzer {
@@ -163,7 +163,7 @@ public class DefaultUsageAnalyzer: BaseUsageAnalyzer {
     }
 }
 
-public class LocalUsageAnalyzer: BaseUsageAnalyzer {
+public class LocalUsageAnalyzer: BaseUsageAnalyzer, LocalsUsageAnalyzer {
     public var functionBody: FunctionBodyIntention
     
     public init(functionBody: FunctionBodyIntention, typeSystem: TypeSystem) {

--- a/Tests/ExpressionPassesTests/DefaultExpressionPassesTests.swift
+++ b/Tests/ExpressionPassesTests/DefaultExpressionPassesTests.swift
@@ -21,6 +21,7 @@ class DefaultExpressionPassesTests: XCTestCase {
         XCTAssert(passes.next() == NumberCommonsExpressionPass.self)
         XCTAssert(passes.next() == EnumRewriterExpressionPass.self)
         XCTAssert(passes.next() == LocalConstantPromotionExpressionPass.self)
+        XCTAssert(passes.next() == VariableNullabilityPromotionExpressionPass.self)
         XCTAssert(passes.next() == ASTSimplifier.self)
         XCTAssertNil(passes.next())
     }

--- a/Tests/ExpressionPassesTests/LocalConstantPromotionExpressionPassTests.swift
+++ b/Tests/ExpressionPassesTests/LocalConstantPromotionExpressionPassTests.swift
@@ -16,13 +16,11 @@ class LocalConstantPromotionExpressionPassTests: ExpressionPassTestCase {
     }
     
     func testDetectTrivialLetConstant() {
-        
         let body: CompoundStatement = [
             Statement.variableDeclaration(identifier: "test",
                                           type: .int,
                                           initialization: .constant(0))
         ]
-        
         functionBodyContext = FunctionBodyIntention(body: body)
         
         assertTransform(
@@ -34,5 +32,33 @@ class LocalConstantPromotionExpressionPassTests: ExpressionPassTestCase {
                                               initialization: .constant(0))
             ])
         ); assertNotifiedChange()
+    }
+    
+    func testNonConstantCase() {
+        let body: CompoundStatement = [
+            Statement.variableDeclaration(identifier: "test",
+                                          type: .int,
+                                          initialization: .constant(0)),
+            Statement.expression(
+                Expression
+                    .identifier("test").setDefinition(localName: "test", type: .int)
+                    .assignment(op: .equals, rhs: .constant(1))
+            )
+        ]
+        functionBodyContext = FunctionBodyIntention(body: body)
+        
+        assertTransform(
+            statement: body,
+            into: CompoundStatement(statements: [
+                Statement.variableDeclaration(identifier: "test",
+                                              type: .int,
+                                              isConstant: false,
+                                              initialization: .constant(0)),
+                Statement.expression(
+                    Expression
+                        .identifier("test").setDefinition(localName: "test", type: .int)
+                        .assignment(op: .equals, rhs: .constant(1)))
+            ])
+        ); assertDidNotNotifyChange()
     }
 }

--- a/Tests/ExpressionPassesTests/VariableNullabilityPromotionExpressionPassTests.swift
+++ b/Tests/ExpressionPassesTests/VariableNullabilityPromotionExpressionPassTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+import ExpressionPasses
+import SwiftRewriterLib
+import SwiftAST
+import TestCommons
+
+class VariableNullabilityPromotionExpressionPassTests: ExpressionPassTestCase {
+    override func setUp() {
+        super.setUp()
+        
+        sutType = VariableNullabilityPromotionExpressionPass.self
+        intentionContext = .global(
+            GlobalFunctionGenerationIntention(
+                signature: FunctionSignature(name: "test")
+            )
+        )
+    }
+    
+    func testNonNilPromotion() {
+        let statement = Statement
+            .compound([
+                .variableDeclaration(identifier: "a",
+                                     type: SwiftType.nullabilityUnspecified("A"),
+                                     initialization: Expression.identifier("_a").typed("A"))
+            ])
+        functionBodyContext = FunctionBodyIntention(body: statement)
+        
+        assertTransform(
+            statement: statement,
+            into: .compound([
+                .variableDeclaration(identifier: "a",
+                                     type: "A",
+                                     initialization: Expression.identifier("_a").typed("A"))
+            ])
+        ); assertNotifiedChange()
+    }
+    
+    func testDontPromoteUninitializedConstants() {
+        let statement = Statement
+            .compound([
+                .variableDeclaration(identifier: "a",
+                                     type: SwiftType.nullabilityUnspecified("A"),
+                                     initialization: nil)
+            ])
+        functionBodyContext = FunctionBodyIntention(body: statement)
+        
+        assertTransform(
+            statement: statement,
+            into: .compound([
+                .variableDeclaration(identifier: "a",
+                                     type: SwiftType.nullabilityUnspecified("A"),
+                                     initialization: nil)
+            ])
+        ); assertDidNotNotifyChange()
+    }
+    
+    func testDontPromoteNilInitializedVariables() {
+        let statement = Statement
+            .compound([
+                .variableDeclaration(identifier: "a",
+                                     type: SwiftType.nullabilityUnspecified("A"),
+                                     initialization: .constant(.nil))
+                ])
+        functionBodyContext = FunctionBodyIntention(body: statement)
+        
+        assertTransform(
+            statement: statement,
+            into: .compound([
+                .variableDeclaration(identifier: "a",
+                                     type: SwiftType.nullabilityUnspecified("A"),
+                                     initialization: .constant(.nil))
+                ])
+        ); assertDidNotNotifyChange()
+    }
+    
+    func testAvoidPromotingVariableLaterAssignedAsNil() {
+        let statement = Statement
+            .compound([
+                .variableDeclaration(identifier: "a",
+                                     type: SwiftType.nullabilityUnspecified("A"),
+                                     initialization: Expression.identifier("_a").typed("A")),
+                .expression(
+                    Expression
+                        .identifier("a").setDefinition(localName: "a", type: .nullabilityUnspecified("A"))
+                        .assignment(op: .assign, rhs: .constant(.nil))
+                )
+            ])
+        functionBodyContext = FunctionBodyIntention(body: statement)
+        
+        assertTransform(
+            statement: statement,
+            into: .compound([
+                .variableDeclaration(identifier: "a",
+                                     type: SwiftType.nullabilityUnspecified("A"),
+                                     initialization: Expression.identifier("_a").typed("A")),
+                .expression(
+                    Expression
+                        .identifier("a").setDefinition(localName: "a", type: .nullabilityUnspecified("A"))
+                        .assignment(op: .assign, rhs: .constant(.nil))
+                )
+            ])
+        ); assertDidNotNotifyChange()
+    }
+}

--- a/Tests/SwiftRewriterLibTests/SwiftRewriter+NullabilityTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriter+NullabilityTests.swift
@@ -1,0 +1,48 @@
+import SwiftRewriterLib
+import SwiftAST
+import XCTest
+
+class SwiftRewriterNullabilityTests: XCTestCase {
+    
+    func testNonNilInitializedImplicitUnwrappedVariableKeepsNullabilityInCaseNilIsAssignedLater() {
+        // We use initial values of locals to help with determining whether or
+        // not a variable is supposed to be nil or not, since it is very common
+        // to create variables in Objective-C with no explicit nullability
+        // annotations in method bodies.
+        //
+        // This test verifies that when we later assign nil to a variable that
+        // is created with an initial value that is non-nil, the transpiler is
+        // able to detect that case and keep the nullability state of the variable
+        // as implicitly-unwrapped optional (in case no explicit nullability
+        // annotations are defined)
+        
+        assertObjcParse(
+            objc: """
+            @interface A
+            - (instancetype)init;
+            @end
+            
+            void test() {
+                A *nonNil = [A new];
+                A *constantNonNil = [A new];
+                A *lateNilAssignment = [A new];
+                nonNil = [A new];
+                lateNilAssignment = nil;
+            }
+            """,
+            swift: """
+            func test() {
+                var nonNil = A()
+                let constantNonNil = A()
+                var lateNilAssignment: A! = A()
+                nonNil = A()
+                lateNilAssignment = nil
+            }
+
+            class A {
+                override init() {
+                }
+            }
+            """)
+    }
+}

--- a/Tests/SwiftRewriterLibTests/SwiftRewriter+StmtTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriter+StmtTests.swift
@@ -208,7 +208,7 @@ class SwiftRewriter_StmtTests: XCTestCase {
         // Should emit types for nil literals, as well
         assertSingleStatement(
             objc: "NSString *x = nil;",
-            swift: "let x: String? = nil"
+            swift: "let x: String! = nil"
         )
         
         // Keep inferring on for literal-based expressions as well

--- a/Tests/SwiftRewriterLibTests/SwiftRewriterTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriterTests.swift
@@ -582,7 +582,7 @@ class SwiftRewriterTests: XCTestCase {
             """,
             swift: """
             func test() {
-                let msgSend: (@convention(c) (UnsafeMutablePointer<structobjc_super>?, SEL) -> Void)! = { () -> Void in
+                let msgSend: @convention(c) (UnsafeMutablePointer<structobjc_super>?, SEL) -> Void = { () -> Void in
                 }
             }
             """)


### PR DESCRIPTION
Still requires some final touches, such as not promoting nullable to non-nil in the following case:

```objc
NSString *local = nil;
if (test) {
    local = @"value";
}
[self foo:local];
```

Currently it's not implemented correctly, but it should ultimately transform that into:

```swift
var local: String? = nil // Should keep as 'String?', not 'String'
if (test) {
    local = "value"
}
self.foo(local)
```

I'll get around implementing that later on.