### PR TITLE
Support for @IBOutlet and @IBInspectable

### DIFF
--- a/Sources/GrammarModels/ObjcClass+Property.swift
+++ b/Sources/GrammarModels/ObjcClass+Property.swift
@@ -16,6 +16,9 @@ public class PropertyDefinition: ASTNode, InitializableNode {
     // For use in protocol methods only
     public var isOptionalProperty: Bool = false
     
+    public var hasIbOutletSpecifier: Bool = false
+    public var hasIbInspectableSpecifier: Bool = false
+    
     public required init(isInNonnullContext: Bool) {
         super.init(isInNonnullContext: isInNonnullContext)
     }

--- a/Sources/SwiftRewriterLib/IntentionCollector.swift
+++ b/Sources/SwiftRewriterLib/IntentionCollector.swift
@@ -380,6 +380,15 @@ public class IntentionCollector {
             return
         }
         
+        var knownAttributes: [KnownAttribute] = []
+        
+        if node.hasIbOutletSpecifier {
+            knownAttributes.append(KnownAttribute(name: "IBOutlet"))
+        }
+        if node.hasIbInspectableSpecifier {
+            knownAttributes.append(KnownAttribute(name: "IBInspectable"))
+        }
+        
         let swiftType: SwiftType = .anyObject
         
         var ownership: Ownership = .strong
@@ -412,17 +421,20 @@ public class IntentionCollector {
                                                     source: node)
             prop.isOptional = node.isOptionalProperty
             prop.inNonnullContext = delegate?.isNodeInNonnullContext(node) ?? false
+            prop.knownAttributes = knownAttributes
             recordSourceHistory(intention: prop, node: node)
             
             ctx.addProperty(prop)
             
             delegate?.reportForLazyResolving(intention: prop)
         } else {
-            let prop = PropertyGenerationIntention(name: node.identifier?.name ?? "",
-                                                   storage: storage,
-                                                   attributes: attributes,
-                                                   source: node)
+            let prop =
+                PropertyGenerationIntention(name: node.identifier?.name ?? "",
+                                            storage: storage,
+                                            attributes: attributes,
+                                            source: node)
             prop.inNonnullContext = delegate?.isNodeInNonnullContext(node) ?? false
+            prop.knownAttributes = knownAttributes
             recordSourceHistory(intention: prop, node: node)
             
             ctx.addProperty(prop)

--- a/Sources/SwiftRewriterLib/Intentions/GlobalFunctionGenerationIntention.swift
+++ b/Sources/SwiftRewriterLib/Intentions/GlobalFunctionGenerationIntention.swift
@@ -2,7 +2,7 @@ import GrammarModels
 import SwiftAST
 
 /// An intention to generate a global function.
-public class GlobalFunctionGenerationIntention: FromSourceIntention, FileLevelIntention, FunctionIntention {
+public class GlobalFunctionGenerationIntention: FromSourceIntention, FileLevelIntention, FunctionIntention, AttributeTaggeableObject {
     var typedSource: FunctionDefinition? {
         return source as? FunctionDefinition
     }
@@ -26,6 +26,8 @@ public class GlobalFunctionGenerationIntention: FromSourceIntention, FileLevelIn
     }
     
     public var functionBody: FunctionBodyIntention?
+    
+    public var knownAttributes: [KnownAttribute] = []
     
     public init(signature: FunctionSignature,
                 accessLevel: AccessLevel = .internal,

--- a/Sources/SwiftRewriterLib/Intentions/TypeGenerationIntention.swift
+++ b/Sources/SwiftRewriterLib/Intentions/TypeGenerationIntention.swift
@@ -33,6 +33,7 @@ public class TypeGenerationIntention: FromSourceIntention {
     }
     
     public var knownTraits: [String: TraitType] = [:]
+    public var knownAttributes: [KnownAttribute] = []
     
     public var kind: KnownTypeKind {
         return .class
@@ -269,8 +270,5 @@ extension TypeGenerationIntention: KnownType {
     }
     public var knownProtocolConformances: [KnownProtocolConformance] {
         return protocols
-    }
-    public var knownAttributes: [KnownAttribute] {
-        return []
     }
 }

--- a/Sources/SwiftRewriterLib/KnownType/KnownType.swift
+++ b/Sources/SwiftRewriterLib/KnownType/KnownType.swift
@@ -213,6 +213,24 @@ public enum TraitType: Equatable, Codable {
     case swiftType(SwiftType)
     case semantics([Semantic])
     
+    public var asSwiftType: SwiftType? {
+        switch self {
+        case .swiftType(let type):
+            return type
+        default:
+            return nil
+        }
+    }
+    
+    public var asSemantics: [Semantic]? {
+        switch self {
+        case .semantics(let semantics):
+            return semantics
+        default:
+            return nil
+        }
+    }
+    
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         

--- a/Sources/SwiftRewriterLib/KnownType/KnownType.swift
+++ b/Sources/SwiftRewriterLib/KnownType/KnownType.swift
@@ -270,10 +270,10 @@ public struct KnownAttribute: Codable {
             return "@\(name)(\(parameters))"
         }
         
-        return "@\(name)()"
+        return "@\(name)"
     }
     
-    public init(name: String, parameters: String?) {
+    public init(name: String, parameters: String? = nil) {
         self.name = name
         self.parameters = parameters
     }

--- a/Sources/SwiftRewriterLib/KnownType/KnownTypeBuilder.swift
+++ b/Sources/SwiftRewriterLib/KnownType/KnownTypeBuilder.swift
@@ -477,6 +477,88 @@ public struct KnownTypeBuilder {
         return DummyType(type: type)
     }
     
+    /// Returns a type generation intention built from this builder.
+    /// Method and computed property bodies are left empty.
+    public func buildIntention() -> TypeGenerationIntention {
+        let typeIntention: TypeGenerationIntention
+        
+        switch type.kind {
+        case .class:
+            typeIntention = ClassGenerationIntention(typeName: type.typeName)
+            
+        case .struct:
+            typeIntention = StructGenerationIntention(typeName: type.typeName)
+            
+        case .enum:
+            // type.setKnownTrait(KnownTypeTraits.enumRawValue,
+            // value: .swiftType(rawValueType))
+            
+            typeIntention = EnumGenerationIntention(typeName: type.typeName,
+                                                    rawValueType: type.knownTrait(KnownTypeTraits.enumRawValue)?.asSwiftType ?? .int)
+            
+        case .protocol:
+            typeIntention = ProtocolGenerationIntention(typeName: type.typeName)
+        }
+        
+        if let cls = typeIntention as? BaseClassIntention {
+            for ivar in type.knownFields {
+                let intent = InstanceVariableGenerationIntention(name: ivar.name,
+                                                                 storage: ivar.storage)
+                
+                cls.addInstanceVariable(intent)
+            }
+        }
+        if let cls = typeIntention as? ClassGenerationIntention {
+            cls.superclassName = type.supertype?.asTypeName
+        }
+        for prop in type.knownProperties {
+            let intent: PropertyGenerationIntention
+            if type.kind == .protocol {
+                intent = ProtocolPropertyGenerationIntention(name: prop.name,
+                                                             type: prop.storage.type,
+                                                             attributes: prop.attributes)
+            } else {
+                intent = PropertyGenerationIntention(name: prop.name,
+                                                     type: prop.storage.type,
+                                                     attributes: prop.attributes)
+            }
+            
+            switch prop.accessor {
+            case .getter:
+                intent.mode = .computed(FunctionBodyIntention(body: []))
+                
+            case .getterAndSetter:
+                intent.mode = .asField
+            }
+            
+            intent.attributes = prop.attributes
+            intent.knownAttributes = prop.knownAttributes
+            
+            typeIntention.addProperty(intent)
+        }
+        for method in type.knownMethods {
+            let intent = MethodGenerationIntention(signature: method.signature)
+            intent.knownAttributes = method.knownAttributes
+            
+            typeIntention.addMethod(intent)
+        }
+        for prot in type.knownProtocolConformances {
+            let intent = ProtocolInheritanceIntention(protocolName: prot.protocolName)
+            
+            typeIntention.addProtocol(intent)
+        }
+        for ctor in type.knownConstructors {
+            let intent = InitGenerationIntention(parameters: ctor.parameters)
+            intent.isFailable = ctor.isFailable
+            intent.isConvenience = ctor.isConvenience
+        }
+        
+        typeIntention.knownTraits = type.knownTraits
+        typeIntention.knownAttributes = type.knownAttributes
+        
+        return typeIntention
+    }
+    
     /// Encodes the type represented by this known type builder
     ///
     /// - Returns: A data representation of the type being built which can be later

--- a/Sources/SwiftRewriterLib/SwiftWriter.swift
+++ b/Sources/SwiftRewriterLib/SwiftWriter.swift
@@ -239,6 +239,7 @@ class InternalSwiftWriter {
         if options.emitObjcCompatibility {
             target.outputInlineWithSpace("@objc", style: .keyword)
         }
+        outputAttributes(intention.knownAttributes, inline: false, into: target)
         target.outputInlineWithSpace("enum", style: .keyword)
         target.outputInline(intention.typeName, style: .typeName)
         target.outputInline(": ")
@@ -267,6 +268,7 @@ class InternalSwiftWriter {
     func outputStruct(_ str: StructGenerationIntention, target: RewriterOutputTarget) {
         outputHistory(for: str, target: target)
         
+        outputAttributes(str.knownAttributes, inline: false, into: target)
         target.outputInlineWithSpace("struct", style: .keyword)
         target.outputInline(str.typeName, style: .typeName)
         
@@ -322,6 +324,8 @@ class InternalSwiftWriter {
     func outputFunctionDeclaration(_ funcDef: GlobalFunctionGenerationIntention, target: RewriterOutputTarget) {
         outputHistory(for: funcDef, target: target)
         
+        outputAttributes(funcDef.knownAttributes, inline: false, into: target)
+        
         let accessModifier =
             _accessModifierFor(accessLevel: funcDef.accessLevel)
         
@@ -368,6 +372,7 @@ class InternalSwiftWriter {
         if options.emitObjcCompatibility {
             target.output(line: "@objc", style: .keyword)
         }
+        outputAttributes(cls.knownAttributes, inline: false, into: target)
         target.outputIdentation()
         target.outputInlineWithSpace("extension", style: .keyword)
         target.outputInline(cls.typeName, style: .typeName)
@@ -381,6 +386,7 @@ class InternalSwiftWriter {
         if options.emitObjcCompatibility {
             target.output(line: "@objc", style: .keyword)
         }
+        outputAttributes(cls.knownAttributes, inline: false, into: target)
         target.outputIdentation()
         target.outputInlineWithSpace("class", style: .keyword)
         target.outputInline(cls.typeName, style: .typeName)
@@ -486,7 +492,7 @@ class InternalSwiftWriter {
         if emitObjcAttribute {
             target.output(line: "@objc", style: .keyword)
         }
-        
+        outputAttributes(prot.knownAttributes, inline: false, into: target)
         target.outputIdentation()
         target.outputInlineWithSpace("protocol", style: .keyword)
         target.outputInline(prot.typeName, style: .typeName)
@@ -572,9 +578,7 @@ class InternalSwiftWriter {
             target.outputInlineWithSpace("@objc", style: .keyword)
         }
         
-        for attribute in prop.knownAttributes {
-            target.outputInlineWithSpace(attribute.attributeString, style: .attribute)
-        }
+        outputAttributes(prop.knownAttributes, inline: true, into: target)
         
         let accessModifier = _accessModifierFor(accessLevel: prop.accessLevel)
         let typeName = typeMapper.typeNameString(for: prop.type)
@@ -693,6 +697,7 @@ class InternalSwiftWriter {
         if options.emitObjcCompatibility && (selfType.kind == .class || selfType.kind == .protocol) {
             target.output(line: "@objc", style: .keyword)
         }
+        outputAttributes(initMethod.knownAttributes, inline: false, into: target)
         target.outputIdentation()
         
         let accessModifier = _accessModifierFor(accessLevel: initMethod.accessLevel)
@@ -773,7 +778,7 @@ class InternalSwiftWriter {
         if options.emitObjcCompatibility {
             target.output(line: "@objc", style: .keyword)
         }
-        
+        outputAttributes(method.knownAttributes, inline: false, into: target)
         target.outputIdentation()
         
         let accessModifier = _accessModifierFor(accessLevel: method.accessLevel)
@@ -853,6 +858,19 @@ class InternalSwiftWriter {
         }
         
         target.outputInline(")")
+    }
+    
+    func outputAttributes(_ attributes: [KnownAttribute],
+                          inline: Bool,
+                          into target: RewriterOutputTarget) {
+        
+        for attribute in attributes {
+            if inline {
+                target.outputInlineWithSpace(attribute.attributeString, style: .attribute)
+            } else {
+                target.output(line: attribute.attributeString, style: .attribute)
+            }
+        }
     }
     
     func outputHistory(for intention: Intention, target: RewriterOutputTarget) {

--- a/Sources/SwiftRewriterLib/SwiftWriter.swift
+++ b/Sources/SwiftRewriterLib/SwiftWriter.swift
@@ -572,6 +572,10 @@ class InternalSwiftWriter {
             target.outputInlineWithSpace("@objc", style: .keyword)
         }
         
+        for attribute in prop.knownAttributes {
+            target.outputInlineWithSpace(attribute.attributeString, style: .attribute)
+        }
+        
         let accessModifier = _accessModifierFor(accessLevel: prop.accessLevel)
         let typeName = typeMapper.typeNameString(for: prop.type)
         

--- a/Tests/ObjcParserTests/ObjcParserTests.swift
+++ b/Tests/ObjcParserTests/ObjcParserTests.swift
@@ -354,6 +354,28 @@ class ObjcParserTests: XCTestCase {
         XCTAssertEqual(fields?[0].type?.type, ObjcType.struct("int"))
     }
     
+    func testParseIBOutletProperty() {
+        let node = parserTest("""
+            @interface Foo
+            @property (weak, nonatomic) IBOutlet UILabel *label;
+            @end
+            """)
+        
+        let implementation: ObjcClassInterface? = node.firstChild()
+        XCTAssertEqual(implementation?.properties[0].hasIbOutletSpecifier, true)
+    }
+    
+    func testParseIBInspectableProperty() {
+        let node = parserTest("""
+            @interface Foo
+            @property (weak, nonatomic) IBInspectable UILabel *label;
+            @end
+            """)
+        
+        let implementation: ObjcClassInterface? = node.firstChild()
+        XCTAssertEqual(implementation?.properties[0].hasIbInspectableSpecifier, true)
+    }
+    
     func testParseError() {
         _=parserTest("""
             @interface ViewController (Private)

--- a/Tests/SwiftRewriterLibTests/IntentionCollectorTests.swift
+++ b/Tests/SwiftRewriterLibTests/IntentionCollectorTests.swift
@@ -53,7 +53,6 @@ class IntentionCollectorTests: XCTestCase {
     }
     
     func testCollectFunctionDefinitionBody() throws {
-        // Arrange
         let parser = ObjcParser(string: "void global() { stmt(); }")
         try parser.parse()
         let rootNode = parser.rootNode
@@ -63,6 +62,34 @@ class IntentionCollectorTests: XCTestCase {
         XCTAssertEqual(file.globalFunctionIntentions.count, 1)
         XCTAssertEqual(delegate.reportedForLazyParsing.count, 1)
         XCTAssert(delegate.reportedForLazyParsing.first === file.globalFunctionIntentions.first?.functionBody)
+    }
+    
+    func testCollectPropertyIBOutletAttribute() throws {
+        let parser = ObjcParser(string: """
+            @interface Foo
+            @property (weak, nonatomic) IBOutlet UILabel *label;
+            @end
+            """)
+        try parser.parse()
+        let rootNode = parser.rootNode
+        
+        sut.collectIntentions(rootNode)
+        
+        XCTAssert(file.classIntentions[0].properties[0].knownAttributes.contains { $0.name == "IBOutlet" })
+    }
+    
+    func testCollectPropertyIBInspectableAttribute() throws {
+        let parser = ObjcParser(string: """
+            @interface Foo
+            @property (weak, nonatomic) IBInspectable UILabel *label;
+            @end
+            """)
+        try parser.parse()
+        let rootNode = parser.rootNode
+        
+        sut.collectIntentions(rootNode)
+        
+        XCTAssert(file.classIntentions[0].properties[0].knownAttributes.contains { $0.name == "IBInspectable" })
     }
 }
 

--- a/Tests/SwiftRewriterLibTests/SwiftRewriterTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriterTests.swift
@@ -2608,4 +2608,32 @@ class SwiftRewriterTests: XCTestCase {
             }
             """)
     }
+    
+    func testRewriteIBOutlet() {
+        assertObjcParse(
+            objc: """
+            @interface Foo : NSObject
+            @property (weak, nonatomic) IBOutlet UILabel *label;
+            @end
+            """,
+            swift: """
+            class Foo: NSObject {
+                @IBOutlet weak var label: UILabel?
+            }
+            """)
+    }
+    
+    func testRewriteIBInspectable() {
+        assertObjcParse(
+            objc: """
+            @interface Foo : NSObject
+            @property (weak, nonatomic) IBInspectable UILabel *label;
+            @end
+            """,
+            swift: """
+            class Foo: NSObject {
+                @IBInspectable weak var label: UILabel?
+            }
+            """)
+    }
 }

--- a/Tests/SwiftRewriterLibTests/SwiftWriterTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftWriterTests.swift
@@ -62,4 +62,150 @@ class SwiftWriterTests: XCTestCase {
         
         XCTAssertEqual(output.buffer.trimmingCharacters(in: .whitespacesAndNewlines), expected)
     }
+    
+    func testWriteClassAttributes() {
+        let type = KnownTypeBuilder(typeName: "A", kind: .class)
+            .settingAttributes([
+                KnownAttribute(name: "attr"),
+                KnownAttribute(name: "otherAttr", parameters: ""),
+                KnownAttribute(name: "otherAttr", parameters: "type: Bool")
+            ])
+            .buildIntention()
+        let intent = type as! ClassGenerationIntention
+        
+        sut.outputClass(intent, target: output.outputTarget())
+        
+        let expected = """
+            @attr
+            @otherAttr()
+            @otherAttr(type: Bool)
+            class A {
+            }
+            """
+        
+        XCTAssertEqual(output.buffer.trimmingCharacters(in: .whitespacesAndNewlines), expected)
+    }
+    
+    func testWriteStructAttributes() {
+        let type = KnownTypeBuilder(typeName: "A", kind: .struct)
+            .settingAttributes([
+                KnownAttribute(name: "attr"),
+                KnownAttribute(name: "otherAttr", parameters: ""),
+                KnownAttribute(name: "otherAttr", parameters: "type: Bool")
+            ])
+            .buildIntention()
+        let intent = type as! StructGenerationIntention
+        
+        sut.outputStruct(intent, target: output.outputTarget())
+        
+        let expected = """
+            @attr
+            @otherAttr()
+            @otherAttr(type: Bool)
+            struct A {
+            }
+            """
+        
+        XCTAssertEqual(output.buffer.trimmingCharacters(in: .whitespacesAndNewlines), expected)
+    }
+    
+    func testWriteEnumAttributes() {
+        let type = KnownTypeBuilder(typeName: "A", kind: .enum)
+            .settingAttributes([
+                KnownAttribute(name: "attr"),
+                KnownAttribute(name: "otherAttr", parameters: ""),
+                KnownAttribute(name: "otherAttr", parameters: "type: Bool")
+            ])
+            .buildIntention()
+        let intent = type as! EnumGenerationIntention
+        
+        sut.outputEnum(intent, target: output.outputTarget())
+        
+        let expected = """
+            @attr
+            @otherAttr()
+            @otherAttr(type: Bool)
+            enum A: Int {
+            }
+            """
+        
+        XCTAssertEqual(output.buffer.trimmingCharacters(in: .whitespacesAndNewlines), expected)
+    }
+    
+    func testWriteProtocolAttributes() {
+        let type = KnownTypeBuilder(typeName: "A", kind: .protocol)
+            .settingAttributes([
+                KnownAttribute(name: "attr"),
+                KnownAttribute(name: "otherAttr", parameters: ""),
+                KnownAttribute(name: "otherAttr", parameters: "type: Bool")
+            ])
+            .buildIntention()
+        let intent = type as! ProtocolGenerationIntention
+        
+        sut.outputProtocol(intent, target: output.outputTarget())
+        
+        let expected = """
+            @attr
+            @otherAttr()
+            @otherAttr(type: Bool)
+            protocol A {
+            }
+            """
+        
+        XCTAssertEqual(output.buffer.trimmingCharacters(in: .whitespacesAndNewlines), expected)
+    }
+    
+    func testWritePropertyAttributes() {
+        let type = KnownTypeBuilder(typeName: "A")
+            .property(
+                named: "property",
+                type: .int,
+                attributes: [
+                    KnownAttribute(name: "attr"),
+                    KnownAttribute(name: "otherAttr", parameters: ""),
+                    KnownAttribute(name: "otherAttr", parameters: "type: Bool")
+                ]
+            )
+            .buildIntention()
+        let intent = type as! ClassGenerationIntention
+        
+        sut.outputClass(intent, target: output.outputTarget())
+        
+        let expected = """
+            class A {
+                @attr @otherAttr() @otherAttr(type: Bool) var property: Int = 0
+            }
+            """
+        
+        XCTAssertEqual(output.buffer.trimmingCharacters(in: .whitespacesAndNewlines), expected)
+    }
+    
+    func testWriteMethodAttributes() {
+        let type = KnownTypeBuilder(typeName: "A")
+            .method(
+                named: "method",
+                parsingSignature: "()",
+                attributes: [
+                    KnownAttribute(name: "attr"),
+                    KnownAttribute(name: "otherAttr", parameters: ""),
+                    KnownAttribute(name: "otherAttr", parameters: "type: Bool")
+                ]
+            )
+            .buildIntention()
+        let intent = type as! ClassGenerationIntention
+        
+        sut.outputClass(intent, target: output.outputTarget())
+        
+        let expected = """
+            class A {
+                @attr
+                @otherAttr()
+                @otherAttr(type: Bool)
+                func method() {
+                }
+            }
+            """
+        
+        XCTAssertEqual(output.buffer.trimmingCharacters(in: .whitespacesAndNewlines), expected)
+    }
 }


### PR DESCRIPTION
Basically detects the original annotations in `@property` declarations and converts them to attributes in the matching property declarations in Swift.