### PR TITLE
#define preprocessor conversion

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -76,7 +76,7 @@ let package = Package(
         .target(
             name: "IntentionPasses",
             dependencies: ["SwiftAST", "Commons", "Utils", "MiniLexer",
-                           "Intentions"]),
+                           "Intentions", "GrammarModels"]),
         .target(
             name: "GlobalsProviders",
             dependencies: ["SwiftAST", "Commons", "TypeSystem"]),

--- a/Sources/GrammarModels/ObjcPreprocessorDirective.swift
+++ b/Sources/GrammarModels/ObjcPreprocessorDirective.swift
@@ -1,0 +1,18 @@
+/// An Objective-C preprocessor from an input file
+public struct ObjcPreprocessorDirective: Codable {
+    public var string: String
+    public var range: Range<Int>
+    public var location: SourceLocation
+    public var length: SourceLength
+    
+    public init(string: String,
+                range: Range<Int>,
+                location: SourceLocation,
+                length: SourceLength) {
+        
+        self.string = string
+        self.range = range
+        self.location = location
+        self.length = length
+    }
+}

--- a/Sources/GrammarModels/SourceLength.swift
+++ b/Sources/GrammarModels/SourceLength.swift
@@ -1,5 +1,5 @@
 // Based on SwiftSyntax's own `SourceLength` structure
-public struct SourceLength {
+public struct SourceLength: Codable {
     /// A zero-length source length
     public static let zero: SourceLength =
         SourceLength(newlines: 0, columnsAtLastLine: 0, utf8Length: 0)

--- a/Sources/GrammarModels/SourceLocation.swift
+++ b/Sources/GrammarModels/SourceLocation.swift
@@ -1,5 +1,5 @@
 // Based on SwiftSyntax's own 'AbsolutePosition' structure
-public struct SourceLocation: Comparable {
+public struct SourceLocation: Comparable, Codable {
     public static let invalid = SourceLocation(line: 0, column: 0, utf8Offset: 0)
     
     public var isValid: Bool {

--- a/Sources/IntentionPasses/ImportDirectiveIntentionPass.swift
+++ b/Sources/IntentionPasses/ImportDirectiveIntentionPass.swift
@@ -3,6 +3,7 @@ import SwiftAST
 import Intentions
 import MiniLexer
 import Utils
+import GrammarModels
 
 /// Verifies the #import directives on every file and convert them to the appropriate
 /// Swift lib import declaration.
@@ -48,12 +49,12 @@ public class ImportDirectiveIntentionPass: IntentionPass {
         return modules
     }
     
-    private func parseObjcImports(in directives: [String]) -> [ObjcImportDecl] {
+    private func parseObjcImports(in directives: [ObjcPreprocessorDirective]) -> [ObjcImportDecl] {
         var imports: [ObjcImportDecl] = []
         
         for directive in directives {
             do {
-                let lexer = Lexer(input: directive)
+                let lexer = Lexer(input: directive.string)
                 
                 // "#import <[PATH]>"
                 try lexer.advance(expectingCurrent: "#"); lexer.skipWhitespace()

--- a/Sources/Intentions/FileGenerationIntention.swift
+++ b/Sources/Intentions/FileGenerationIntention.swift
@@ -19,7 +19,7 @@ public final class FileGenerationIntention: Intention {
     public private(set) var typeIntentions: [TypeGenerationIntention] = []
     
     /// All preprocessor directives found on this file.
-    public var preprocessorDirectives: [String] = []
+    public var preprocessorDirectives: [ObjcPreprocessorDirective] = []
     
     /// Gets the (Swift) import directives should be printed at this file's top
     /// header section.
@@ -106,7 +106,7 @@ public final class FileGenerationIntention: Intention {
         targetPath = try container.decode(String.self, forKey: .targetPath)
         
         preprocessorDirectives =
-            try container.decode([String].self, forKey: .preprocessorDirectives)
+            try container.decode([ObjcPreprocessorDirective].self, forKey: .preprocessorDirectives)
         importDirectives =
             try container.decode([String].self, forKey: .importDirectives)
         

--- a/Sources/Intentions/FileLevelIntention.swift
+++ b/Sources/Intentions/FileLevelIntention.swift
@@ -1,5 +1,5 @@
-/// An intention that is to be declared at the file-level, not contained within any
-/// types.
+/// An intention that is to be declared at the file-level, not contained within
+/// any types.
 public protocol FileLevelIntention: IntentionProtocol {
     /// The file this intention is contained within
     var file: FileGenerationIntention? { get }

--- a/Sources/Intentions/FromSourceIntention.swift
+++ b/Sources/Intentions/FromSourceIntention.swift
@@ -114,6 +114,34 @@ public class FromSourceIntention: Intention, NonNullScopedIntention {
         }
     }
     
+    /// Returns `true` if this intention's symbol is visible for a given file intention.
+    ///
+    /// - Parameter file: A file intention to compare the visibility to
+    /// - Returns: `true` if this intention's symbol is visible within the given
+    /// file intention, `false` otherwise.
+    public func isVisible(in file: FileGenerationIntention) -> Bool {
+        switch accessLevel {
+        // Internal/public/open are visible everywhere
+        case .internal, .public, .open:
+            return true
+            
+        case .fileprivate:
+            return self.file?.targetPath == file.targetPath
+            
+        // Type-level visibility
+        case .private:
+            switch self {
+            // Private file-level member is visible to all other declarations on
+            // the same file
+            case is FileLevelIntention:
+                return self.file?.targetPath == file.targetPath
+                
+            default:
+                return false
+            }
+        }
+    }
+    
     private enum CodingKeys: String, CodingKey {
         case accessLevel
         case inNonnullContext

--- a/Sources/ObjcParser/ObjcParser.swift
+++ b/Sources/ObjcParser/ObjcParser.swift
@@ -4,19 +4,10 @@ import GrammarModels
 import class Antlr4.BaseErrorListener
 import class Antlr4.Recognizer
 import class Antlr4.ATNSimulator
-import class Antlr4.ANTLRInputStream
-import class Antlr4.CommonTokenStream
 import class Antlr4.ParseTreeWalker
 import class Antlr4.ParserRuleContext
-import class Antlr4.Lexer
 import class Antlr4.Parser
 import ObjcParserAntlr
-
-public struct AntlrParser<Lexer: Antlr4.Lexer, Parser: Antlr4.Parser> {
-    public var lexer: Lexer
-    public var parser: Parser
-    public var tokens: CommonTokenStream
-}
 
 /// Describes settings for ANTLR parsing for an `ObjcParser` instance.
 public struct AntlrSettings {
@@ -26,41 +17,6 @@ public struct AntlrSettings {
     
     public init(forceUseLLPrediction: Bool) {
         self.forceUseLLPrediction = forceUseLLPrediction
-    }
-}
-
-public typealias ObjectiveCParserAntlr = AntlrParser<ObjectiveCLexer, ObjectiveCParser>
-public typealias ObjectiveCPreprocessorAntlr = AntlrParser<ObjectiveCPreprocessorLexer, ObjectiveCPreprocessorParser>
-
-/// Describes a parser state for a single `ObjcParser` instance, with internal
-/// fields that are used by the parser.
-///
-/// - Note: State instances do not support simultaneous usage across many
-/// `ObjcParser` instances concurrently.
-public final class ObjcParserState {
-    var parserState = (lexer: ObjectiveCLexer.State(), parser: ObjectiveCParser.State())
-    var preprocessorState = (lexer: ObjectiveCPreprocessorLexer.State(), parser: ObjectiveCPreprocessorParser.State())
-    
-    public init() {
-        
-    }
-    
-    public func makeMainParser(input: String) throws -> ObjectiveCParserAntlr {
-        let input = ANTLRInputStream(input)
-        let lxr = ObjectiveCLexer(input, parserState.lexer)
-        let tokens = CommonTokenStream(lxr)
-        let parser = try ObjectiveCParser(tokens, parserState.parser)
-        
-        return ObjectiveCParserAntlr(lexer: lxr, parser: parser, tokens: tokens)
-    }
-    
-    public func makePreprocessorParser(input: String) throws -> ObjectiveCPreprocessorAntlr {
-        let input = ANTLRInputStream(input)
-        let lxr = ObjectiveCPreprocessorLexer(input, preprocessorState.lexer)
-        let tokens = CommonTokenStream(lxr)
-        let parser = try ObjectiveCPreprocessorParser(tokens, preprocessorState.parser)
-        
-        return ObjectiveCPreprocessorAntlr(lexer: lxr, parser: parser, tokens: tokens)
     }
 }
 

--- a/Sources/ObjcParser/ObjcParserState.swift
+++ b/Sources/ObjcParser/ObjcParserState.swift
@@ -1,0 +1,46 @@
+import class Antlr4.ANTLRInputStream
+import class Antlr4.CommonTokenStream
+import class Antlr4.Lexer
+import class Antlr4.Parser
+import ObjcParserAntlr
+
+public struct AntlrParser<Lexer: Antlr4.Lexer, Parser: Antlr4.Parser> {
+    public var lexer: Lexer
+    public var parser: Parser
+    public var tokens: CommonTokenStream
+}
+
+public typealias ObjectiveCParserAntlr = AntlrParser<ObjectiveCLexer, ObjectiveCParser>
+public typealias ObjectiveCPreprocessorAntlr = AntlrParser<ObjectiveCPreprocessorLexer, ObjectiveCPreprocessorParser>
+
+/// Describes a parser state for a single `ObjcParser` instance, with internal
+/// fields that are used by the parser.
+///
+/// - Note: State instances do not support simultaneous usage across many
+/// `ObjcParser` instances concurrently.
+public final class ObjcParserState {
+    var parserState = (lexer: ObjectiveCLexer.State(), parser: ObjectiveCParser.State())
+    var preprocessorState = (lexer: ObjectiveCPreprocessorLexer.State(), parser: ObjectiveCPreprocessorParser.State())
+    
+    public init() {
+        
+    }
+    
+    public func makeMainParser(input: String) throws -> ObjectiveCParserAntlr {
+        let input = ANTLRInputStream(input)
+        let lxr = ObjectiveCLexer(input, parserState.lexer)
+        let tokens = CommonTokenStream(lxr)
+        let parser = try ObjectiveCParser(tokens, parserState.parser)
+        
+        return ObjectiveCParserAntlr(lexer: lxr, parser: parser, tokens: tokens)
+    }
+    
+    public func makePreprocessorParser(input: String) throws -> ObjectiveCPreprocessorAntlr {
+        let input = ANTLRInputStream(input)
+        let lxr = ObjectiveCPreprocessorLexer(input, preprocessorState.lexer)
+        let tokens = CommonTokenStream(lxr)
+        let parser = try ObjectiveCPreprocessorParser(tokens, preprocessorState.parser)
+        
+        return ObjectiveCPreprocessorAntlr(lexer: lxr, parser: parser, tokens: tokens)
+    }
+}

--- a/Sources/SwiftRewriterLib/ObjcParserStatePool.swift
+++ b/Sources/SwiftRewriterLib/ObjcParserStatePool.swift
@@ -14,7 +14,7 @@ public final class ObjcParserStatePool {
     /// Pulls a new instance of an `ObjcParserState` to parse with.
     ///
     /// - Returns: An `ObjcParserState` ready to parse data.
-    func pull() -> ObjcParserState {
+    public func pull() -> ObjcParserState {
         mutex.locking {
             if !pool.isEmpty {
                 return pool.removeFirst()
@@ -27,7 +27,7 @@ public final class ObjcParserStatePool {
     /// Repools and `ObjcParserState` instance for reusal.
     ///
     /// - Parameter parserState: Parser state to reuse.
-    func repool(_ parserState: ObjcParserState) {
+    public func repool(_ parserState: ObjcParserState) {
         mutex.locking {
             pool.append(parserState)
         }

--- a/Sources/SwiftRewriterLib/PreprocessorDirectiveConverter.swift
+++ b/Sources/SwiftRewriterLib/PreprocessorDirectiveConverter.swift
@@ -1,0 +1,195 @@
+import SwiftAST
+import MiniLexer
+import Intentions
+import ObjcParser
+import ObjcParserAntlr
+import TypeSystem
+
+/// Converts preprocessor directives into global variable declarations, in case
+/// they represent simple constants.
+public class PreprocessorDirectiveConverter {
+    let parserStatePool: ObjcParserStatePool
+    let typeSystem: TypeSystem
+    let typeResolverInvoker: TypeResolverInvoker
+    
+    public init(parserStatePool: ObjcParserStatePool,
+                typeSystem: TypeSystem,
+                typeResolverInvoker: TypeResolverInvoker) {
+        
+        self.parserStatePool = parserStatePool
+        self.typeSystem = typeSystem
+        self.typeResolverInvoker = typeResolverInvoker
+    }
+    
+    public func convert(directive directiveString: String,
+                        inFile file: FileGenerationIntention) -> DirectiveDeclaration? {
+        
+        guard let directive = processDirective(directiveString) else {
+            return nil
+        }
+
+        let state = parserStatePool.pull()
+        defer { parserStatePool.repool(state) }
+        
+        guard let parser = try? state.makeMainParser(input: directive.expression) else {
+            return nil
+        }
+        guard let expressionContext = try? parser.parser.expression() else {
+            return nil
+        }
+        
+        let expression = expressionFromExpressionContext(expressionContext)
+        
+        guard let declaration = validateExpression(expression, fromFile: file) else {
+            return nil
+        }
+        
+        return DirectiveDeclaration(name: directive.identifier,
+                                    type: declaration.type,
+                                    expresion: declaration.expression)
+    }
+    
+    func processDirective(_ directive: String) -> Directive? {
+        do {
+            let lexer = Lexer(input: directive)
+            lexer.skipWhitespace()
+            try lexer.advance(expectingCurrent: "#")
+            lexer.skipWhitespace()
+            try lexer.consume(match: "define")
+            lexer.skipWhitespace()
+            
+            let identifier = String(try lexer.lexIdentifier())
+            let expression = String(lexer.consumeRemaining())
+            
+            return Directive(identifier: identifier, expression: expression)
+        } catch {
+            return nil
+        }
+    }
+    
+    func expressionFromExpressionContext(_ ctx: ObjectiveCParser.ExpressionContext) -> Expression {
+        let state = parserStatePool.pull()
+        defer { parserStatePool.repool(state) }
+        
+        let astReader = SwiftASTReader(typeMapper: DefaultTypeMapper(typeSystem: typeSystem),
+                                       typeParser: TypeParsing(state: state))
+        
+        return astReader.parseExpression(expression: ctx)
+    }
+    
+    func validateExpression(_ exp: Expression, fromFile file: FileGenerationIntention) -> Declaration? {
+        let validator = ValidatorExpressionVisitor()
+        if !validator.visitExpression(exp) {
+            return nil
+        }
+        
+        typeResolverInvoker
+            .resolveGlobalExpressionType(in: exp, inFile: file, force: true)
+        
+        guard !exp.isErrorTyped, let resolvedType = exp.resolvedType else {
+            return nil
+        }
+        
+        return Declaration(type: resolvedType, expression: exp)
+    }
+    
+    struct Directive {
+        var identifier: String
+        var expression: String
+    }
+    
+    struct Declaration {
+        var type: SwiftType
+        var expression: Expression
+    }
+}
+
+/// Defines a variable declaration that was extracted from a preprocessor
+/// directive
+public struct DirectiveDeclaration {
+    public var name: String
+    public var type: SwiftType
+    public var expresion: Expression
+    
+    public init(name: String, type: SwiftType, expresion: Expression) {
+        self.name = name
+        self.type = type
+        self.expresion = expresion
+    }
+}
+
+/// Validates that expressions can be properly converted into constant expressions
+private class ValidatorExpressionVisitor: ExpressionVisitor {
+    func visitExpression(_ expression: Expression) -> Bool {
+        return expression.accept(self)
+    }
+    
+    func visitAssignment(_ exp: AssignmentExpression) -> Bool {
+        return false
+    }
+    
+    // TODO: Validate binary operator
+    func visitBinary(_ exp: BinaryExpression) -> Bool {
+        return exp.lhs.accept(self) && exp.rhs.accept(self)
+    }
+    
+    // TODO: Validate unary operator
+    func visitUnary(_ exp: UnaryExpression) -> Bool {
+        return exp.exp.accept(self)
+    }
+    
+    // TODO: Don't see why not support sizeof expressions
+    func visitSizeOf(_ exp: SizeOfExpression) -> Bool {
+        return false
+    }
+    
+    // TODO: Validate prefix operator
+    func visitPrefix(_ exp: PrefixExpression) -> Bool {
+        return exp.exp.accept(self)
+    }
+    
+    func visitPostfix(_ exp: PostfixExpression) -> Bool {
+        return exp.exp.accept(self)
+    }
+    
+    // TODO: Validate constant types
+    func visitConstant(_ exp: ConstantExpression) -> Bool {
+        return true
+    }
+    
+    func visitParens(_ exp: ParensExpression) -> Bool {
+        return exp.exp.accept(self)
+    }
+    
+    func visitIdentifier(_ exp: IdentifierExpression) -> Bool {
+        return true
+    }
+    
+    func visitCast(_ exp: CastExpression) -> Bool {
+        return exp.exp.accept(self)
+    }
+    
+    func visitArray(_ exp: ArrayLiteralExpression) -> Bool {
+        return exp.subExpressions.reduce(true, { $0 && $1.accept(self) })
+    }
+    
+    func visitDictionary(_ exp: DictionaryLiteralExpression) -> Bool {
+        return exp.pairs.reduce(true, { $0 && $1.key.accept(self) && $1.value.accept(self) })
+    }
+    
+    func visitBlock(_ exp: BlockLiteralExpression) -> Bool {
+        return false
+    }
+    
+    func visitTernary(_ exp: TernaryExpression) -> Bool {
+        return exp.exp.accept(self) && exp.ifTrue.accept(self) && exp.ifFalse.accept(self)
+    }
+    
+    func visitTuple(_ exp: TupleExpression) -> Bool {
+        return exp.elements.reduce(true, { $0 && $1.accept(self) })
+    }
+    
+    func visitUnknown(_ exp: UnknownExpression) -> Bool {
+        return false
+    }
+}

--- a/Sources/SwiftRewriterLib/PreprocessorDirectiveConverter.swift
+++ b/Sources/SwiftRewriterLib/PreprocessorDirectiveConverter.swift
@@ -159,7 +159,6 @@ private class ValidatorExpressionVisitor: ExpressionVisitor {
         }
     }
     
-    // TODO: Validate prefix operator
     func visitPrefix(_ exp: PrefixExpression) -> Bool {
         return exp.exp.accept(self)
     }
@@ -168,7 +167,6 @@ private class ValidatorExpressionVisitor: ExpressionVisitor {
         return exp.exp.accept(self)
     }
     
-    // TODO: Validate constant types
     func visitConstant(_ exp: ConstantExpression) -> Bool {
         return true
     }

--- a/Sources/SwiftRewriterLib/PreprocessorDirectiveConverter.swift
+++ b/Sources/SwiftRewriterLib/PreprocessorDirectiveConverter.swift
@@ -142,19 +142,21 @@ private class ValidatorExpressionVisitor: ExpressionVisitor {
         return false
     }
     
-    // TODO: Validate binary operator
     func visitBinary(_ exp: BinaryExpression) -> Bool {
         return exp.lhs.accept(self) && exp.rhs.accept(self)
     }
     
-    // TODO: Validate unary operator
     func visitUnary(_ exp: UnaryExpression) -> Bool {
         return exp.exp.accept(self)
     }
     
-    // TODO: Don't see why not support sizeof expressions
     func visitSizeOf(_ exp: SizeOfExpression) -> Bool {
-        return false
+        switch exp.value {
+        case .type(let type):
+            return typeSystem.isScalarType(type) || typeSystem.typeExists(type)
+        default:
+            return false
+        }
     }
     
     // TODO: Validate prefix operator

--- a/Sources/SwiftRewriterLib/SwiftRewriter.swift
+++ b/Sources/SwiftRewriterLib/SwiftRewriter.swift
@@ -255,7 +255,7 @@ public final class SwiftRewriter {
                         typeSystem: typeSystem,
                         typeResolverInvoker: resolver)
                 
-                guard let declaration = converter.convert(directive: directive, inFile: file) else {
+                guard let declaration = converter.convert(directive: directive.string, inFile: file) else {
                     continue
                 }
                 
@@ -271,7 +271,14 @@ public final class SwiftRewriter {
                 
                 varDecl.storage.isConstant = true
                 varDecl.initialValue = declaration.expresion
-                varDecl.history.recordCreation(description: "Converted from compiler directive \(directive)")
+                
+                let sourceName = (file.sourcePath as NSString).lastPathComponent
+                let history = """
+                    Converted from compiler directive from \(sourceName) \
+                    line \(directive.location.line): \(directive.string)
+                    """
+                
+                varDecl.history.recordCreation(description: history)
                 
                 file.addGlobalVariable(varDecl)
                 

--- a/Sources/SwiftSyntaxSupport/SwiftSyntaxProducer.swift
+++ b/Sources/SwiftSyntaxSupport/SwiftSyntaxProducer.swift
@@ -297,7 +297,7 @@ extension SwiftSyntaxProducer {
         var trivia: Trivia = .lineComment("// Preprocessor directives found in file:")
         
         for directive in file.preprocessorDirectives {
-            trivia = trivia + .newlines(1) + .lineComment("// \(directive)")
+            trivia = trivia + .newlines(1) + .lineComment("// \(directive.string)")
         }
         
         return trivia

--- a/Sources/TestCommons/IntentionCollectionBuilder.swift
+++ b/Sources/TestCommons/IntentionCollectionBuilder.swift
@@ -287,7 +287,23 @@ public class FileIntentionBuilder {
     }
     
     @discardableResult
-    public func addPreprocessorDirective(_ directive: String) -> FileIntentionBuilder {
+    public func addPreprocessorDirective(_ directive: String, line: Int) -> FileIntentionBuilder {
+        let location = SourceLocation(line: line, column: 1, utf8Offset: 0)
+        let lineRanges = directive.lineRanges()
+        
+        let columnsAtLastLine = lineRanges.count == 1
+            ? directive.count
+            : directive.distance(from: lineRanges.last!.lowerBound, to: lineRanges.last!.upperBound)
+        
+        let length = SourceLength(newlines: lineRanges.count - line,
+                                  columnsAtLastLine: columnsAtLastLine,
+                                  utf8Length: directive.count)
+        
+        let directive = ObjcPreprocessorDirective(string: directive,
+                                                  range: 0..<directive.count,
+                                                  location: location,
+                                                  length: length)
+        
         intention.preprocessorDirectives.append(directive)
         
         return self

--- a/Sources/TypeSystem/IntentionCollectionTypeSystem.swift
+++ b/Sources/TypeSystem/IntentionCollectionTypeSystem.swift
@@ -76,7 +76,7 @@ public class IntentionCollectionTypeSystem: TypeSystem {
         return super.isClassInstanceType(typeName)
     }
     
-    public override func typeExists(_ name: String) -> Bool {
+    public override func nominalTypeExists(_ name: String) -> Bool {
         if let cache = intentionsProvider.cache {
             if cache.types.keys.contains(name) {
                 return true
@@ -89,7 +89,7 @@ public class IntentionCollectionTypeSystem: TypeSystem {
             }
         }
         
-        return super.typeExists(name)
+        return super.nominalTypeExists(name)
     }
     
     private class IntentionCollectionProvider: TypealiasProvider, KnownTypeProvider {

--- a/Sources/TypeSystem/TypeResolution/ExpressionTypeResolver.swift
+++ b/Sources/TypeSystem/TypeResolution/ExpressionTypeResolver.swift
@@ -675,7 +675,7 @@ extension ExpressionTypeResolver {
         }
         
         // Check type system for a metatype with the identifier name
-        if typeSystem.typeExists(exp.identifier) {
+        if typeSystem.nominalTypeExists(exp.identifier) {
             return CodeDefinition.forType(named: exp.identifier)
         }
         

--- a/Sources/TypeSystem/TypeSystem.swift
+++ b/Sources/TypeSystem/TypeSystem.swift
@@ -114,8 +114,8 @@ public class TypeSystem {
         return expanded1 == expanded2
     }
     
-    /// Returns `true` if a type is known to exists with a given name.
-    public func typeExists(_ name: String) -> Bool {
+    /// Returns `true` if a type with a given name is known.
+    public func nominalTypeExists(_ name: String) -> Bool {
         if _typeExistsCache.usingCache, let result = typeExistsCache[name] {
             return result
         }
@@ -135,6 +135,18 @@ public class TypeSystem {
         }
         
         return result
+    }
+    
+    /// Returns `true` if a given type is known to exist.
+    ///
+    /// Returns `false` for typenames other than `.nominal` and `.metatype` of
+    /// nominals.
+    public func typeExists(_ type: SwiftType) -> Bool {
+        guard let typeName = typeNameIn(swiftType: type) else {
+            return false
+        }
+        
+        return nominalTypeExists(typeName)
     }
     
     /// Returns all known types that match a specified type
@@ -1209,6 +1221,10 @@ extension TypeSystem {
     }
 }
 
+/// Returns the contained type name within a given type.
+///
+/// Returns the nominal type name for `.nominal` and `.metatype` types of nominal
+/// types, `nil` otherwise.
 func typeNameIn(swiftType: SwiftType) -> String? {
     let swiftType = swiftType.deepUnwrapped
     

--- a/Tests/IntentionPassesTests/ImportDirectiveIntentionPassTests.swift
+++ b/Tests/IntentionPassesTests/ImportDirectiveIntentionPassTests.swift
@@ -8,9 +8,9 @@ class ImportDirectiveIntentionPassTests: XCTestCase {
         let intentions =
             IntentionCollectionBuilder()
                 .createFile(named: "file") { file in
-                    file.addPreprocessorDirective("#import <UIKit/UIKit.h>")
-                        .addPreprocessorDirective("#import <Foundation/Foundation.h>")
-                        .addPreprocessorDirective("#import <Framework.h>")
+                    file.addPreprocessorDirective("#import <UIKit/UIKit.h>", line: 1)
+                        .addPreprocessorDirective("#import <Foundation/Foundation.h>", line: 2)
+                        .addPreprocessorDirective("#import <Framework.h>", line: 3)
                 }.build()
         let sut = ImportDirectiveIntentionPass()
         

--- a/Tests/IntentionsTests/Serialization/IntentionSerializerTests.swift
+++ b/Tests/IntentionsTests/Serialization/IntentionSerializerTests.swift
@@ -10,7 +10,7 @@ class IntentionSerializerTests: XCTestCase {
         
         let intentions = IntentionCollectionBuilder()
             .createFile(named: "A.swift") { file in
-                file.addPreprocessorDirective("#preprocessor")
+                file.addPreprocessorDirective("#preprocessor", line: 1)
                     .createClass(withName: "Class") { type in
                         type.createConformance(protocolName: "Protocol")
                             .createConstructor()

--- a/Tests/SwiftRewriterLibTests/FixtureBuilders/SingleFileTestUtils.swift
+++ b/Tests/SwiftRewriterLibTests/FixtureBuilders/SingleFileTestUtils.swift
@@ -26,12 +26,15 @@ class SingleFileTestBuilder {
     }
     
     func assertObjcParse(swift expectedSwift: String,
+                         fileName: String = "test.m",
                          expectsErrors: Bool = false,
                          file: String = #file,
                          line: Int = #line) {
         
         let output = TestSingleFileWriterOutput()
-        let input = TestSingleInputProvider(code: objc, isPrimary: true)
+        let input = TestSingleInputProvider(fileName: fileName,
+                                            code: objc,
+                                            isPrimary: true)
         
         let sut = SwiftRewriter(input: input, output: output)
         sut.writerOptions = options
@@ -92,10 +95,16 @@ class SingleFileTestBuilder {
 }
 
 class TestSingleInputProvider: InputSourcesProvider, InputSource {
+    var fileName: String
     var code: String
     var isPrimary: Bool
     
-    init(code: String, isPrimary: Bool) {
+    convenience init(code: String, isPrimary: Bool) {
+        self.init(fileName: "\(type(of: self)).m", code: code, isPrimary: isPrimary)
+    }
+    
+    init(fileName: String, code: String, isPrimary: Bool) {
+        self.fileName = fileName
         self.code = code
         self.isPrimary = isPrimary
     }
@@ -105,7 +114,7 @@ class TestSingleInputProvider: InputSourcesProvider, InputSource {
     }
     
     func sourcePath() -> String {
-        return "\(type(of: self)).m"
+        return fileName
     }
     
     func loadSource() throws -> CodeSource {
@@ -139,6 +148,7 @@ extension XCTestCase {
     
     @discardableResult
     func assertRewrite(objc: String, swift expectedSwift: String,
+                       inputFileName: String = "test.m",
                        options: SwiftSyntaxOptions = .default,
                        rewriterSettings: SwiftRewriter.Settings = .default,
                        expectsErrors: Bool = false,
@@ -151,6 +161,7 @@ extension XCTestCase {
                                          settings: rewriterSettings)
         
         test.assertObjcParse(swift: expectedSwift,
+                             fileName: inputFileName,
                              expectsErrors: expectsErrors,
                              file: file, line: line)
         

--- a/Tests/SwiftRewriterLibTests/PreprocessorDirectiveConverterTests.swift
+++ b/Tests/SwiftRewriterLibTests/PreprocessorDirectiveConverterTests.swift
@@ -82,6 +82,14 @@ class PreprocessorDirectiveConverterTests: XCTestCase {
         XCTAssertEqual(result?.expresion, Expression.identifier("symbol"))
     }
     
+    func testConvertSizeofExpressions() {
+        let result = sut.convert(directive: "#define CONSTANT sizeof(int)", inFile: file)
+        
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.type, "Int")
+        XCTAssertEqual(result?.expresion, Expression.sizeof(type: "CInt"))
+    }
+    
     func testDontConvertUnevenExpressions() {
         let result = sut.convert(directive: "#define CONSTANT (1", inFile: file)
         

--- a/Tests/SwiftRewriterLibTests/PreprocessorDirectiveConverterTests.swift
+++ b/Tests/SwiftRewriterLibTests/PreprocessorDirectiveConverterTests.swift
@@ -90,6 +90,14 @@ class PreprocessorDirectiveConverterTests: XCTestCase {
         XCTAssertEqual(result?.expresion, Expression.sizeof(type: "CInt"))
     }
     
+    func testConvertNilConstant() {
+        let result = sut.convert(directive: "#define CONSTANT nil", inFile: file)
+        
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.type, .optional("AnyObject"))
+        XCTAssertEqual(result?.expresion, .constant(.nil))
+    }
+    
     func testDontConvertUnevenExpressions() {
         let result = sut.convert(directive: "#define CONSTANT (1", inFile: file)
         

--- a/Tests/SwiftRewriterLibTests/PreprocessorDirectiveConverterTests.swift
+++ b/Tests/SwiftRewriterLibTests/PreprocessorDirectiveConverterTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+import Intentions
+import TypeSystem
+import SwiftAST
+import SwiftRewriterLib
+
+class PreprocessorDirectiveConverterTests: XCTestCase {
+    var file: FileGenerationIntention!
+    var sut: PreprocessorDirectiveConverter!
+    var typeSystem: IntentionCollectionTypeSystem!
+    var typeResolverInvoker: DefaultTypeResolverInvoker!
+    
+    override func setUp() {
+        super.setUp()
+        
+        file = FileGenerationIntention(sourcePath: "A.h", targetPath: "A.swift")
+        
+        let intentionCollection = IntentionCollection()
+        intentionCollection.addIntention(file)
+        
+        typeSystem = IntentionCollectionTypeSystem(intentions: intentionCollection)
+        
+        typeResolverInvoker =
+            DefaultTypeResolverInvoker(globals: ArrayDefinitionsSource(definitions: []),
+                                       typeSystem: typeSystem,
+                                       numThreads: 1)
+        
+        sut = PreprocessorDirectiveConverter(parserStatePool: ObjcParserStatePool(),
+                                             typeSystem: typeSystem,
+                                             typeResolverInvoker: typeResolverInvoker)
+    }
+    
+    func testConvertIntConstant() {
+        let result = sut.convert(directive: "#define CONSTANT 1", inFile: file)
+        
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.type, .int)
+        XCTAssertEqual(result?.expresion, .constant(1))
+    }
+    
+    func testConvertBoolConstant() {
+        let result = sut.convert(directive: "#define CONSTANT true", inFile: file)
+        
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.type, .bool)
+        XCTAssertEqual(result?.expresion, .constant(true))
+    }
+    
+    func testConvertStringConstant() {
+        let result = sut.convert(directive: "#define CONSTANT \"A constant\"", inFile: file)
+        
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.type, .string)
+        XCTAssertEqual(result?.expresion, .constant("A constant"))
+    }
+    
+    func testConvertBinaryExpression() {
+        let result = sut.convert(directive: "#define CONSTANT 1 + 1", inFile: file)
+        
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.type, .int)
+        XCTAssertEqual(result?.expresion, Expression.constant(1).binary(op: .add, rhs: .constant(1)))
+    }
+    
+    func testConvertSymbolReferencingExistingDeclarations() {
+        let v = GlobalVariableGenerationIntention(name: "symbol", type: .int)
+        file.addGlobalVariable(v)
+        typeResolverInvoker.refreshIntentionGlobals()
+        
+        let result = sut.convert(directive: "#define CONSTANT symbol", inFile: file)
+        
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.type, .int)
+        XCTAssertEqual(result?.expresion, Expression.identifier("symbol"))
+    }
+    
+    func testDontConvertUnevenExpressions() {
+        let result = sut.convert(directive: "#define CONSTANT (1", inFile: file)
+        
+        XCTAssertNil(result)
+    }
+    
+    func testDontConvertExpressionsReferencingUnknownSymbols() {
+        let result = sut.convert(directive: "#define CONSTANT SYMBOL", inFile: file)
+        
+        XCTAssertNil(result)
+    }
+    
+    func testDontConvertInvalidBinaryExpression() {
+        let result = sut.convert(directive: "#define CONSTANT \"1\" + 1", inFile: file)
+        
+        XCTAssertNil(result)
+    }
+}

--- a/Tests/SwiftRewriterLibTests/PreprocessorDirectiveConverterTests.swift
+++ b/Tests/SwiftRewriterLibTests/PreprocessorDirectiveConverterTests.swift
@@ -62,6 +62,14 @@ class PreprocessorDirectiveConverterTests: XCTestCase {
         XCTAssertEqual(result?.expresion, Expression.constant(1).binary(op: .add, rhs: .constant(1)))
     }
     
+    func testConvertScalarTypeCasts() {
+        let result = sut.convert(directive: "#define CONSTANT (unsigned int)1", inFile: file)
+        
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.type, .optional("CUnsignedInt"))
+        XCTAssertEqual(result?.expresion, Expression.cast(.constant(1), type: "CUnsignedInt"))
+    }
+    
     func testConvertSymbolReferencingExistingDeclarations() {
         let v = GlobalVariableGenerationIntention(name: "symbol", type: .int)
         file.addGlobalVariable(v)
@@ -88,6 +96,18 @@ class PreprocessorDirectiveConverterTests: XCTestCase {
     
     func testDontConvertInvalidBinaryExpression() {
         let result = sut.convert(directive: "#define CONSTANT \"1\" + 1", inFile: file)
+        
+        XCTAssertNil(result)
+    }
+    
+    func testDontConvertMacrosWithParameters() {
+        let result = sut.convert(directive: "#define MACRO(c) 1", inFile: file)
+        
+        XCTAssertNil(result)
+    }
+    
+    func testDontConvertNonScalarTypeCasts() {
+        let result = sut.convert(directive: "#define MACRO (UnknownType)1", inFile: file)
         
         XCTAssertNil(result)
     }

--- a/Tests/SwiftRewriterLibTests/SwiftRewriter+IntentionPassHistoryTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriter+IntentionPassHistoryTests.swift
@@ -24,12 +24,12 @@ class SwiftRewriter_IntentionPassHistoryTests: XCTestCase {
             @end
             """,
             swift: """
-            // [Creation] TestSingleInputProvider.m line 1 column 1
-            // [Creation] TestSingleInputProvider.m line 12 column 1
+            // [Creation] test.m line 1 column 1
+            // [Creation] test.m line 12 column 1
             // [PropertyMergeIntentionPass:1] Removed method MyClass.value() -> Bool since deduced it is a getter for property MyClass.value: Bool
             // [PropertyMergeIntentionPass:1] Removed method MyClass.setValue(_ value: Bool) since deduced it is a setter for property MyClass.value: Bool
             class MyClass {
-                // [Creation] TestSingleInputProvider.m line 13 column 1
+                // [Creation] test.m line 13 column 1
                 // [PropertyMergeIntentionPass:1] Merged MyClass.value() -> Bool and MyClass.setValue(_ value: Bool) into property MyClass.value: Bool
                 var value: Bool {
                     get {
@@ -39,7 +39,7 @@ class SwiftRewriter_IntentionPassHistoryTests: XCTestCase {
                     }
                 }
             
-                // [Creation] TestSingleInputProvider.m line 8 column 3
+                // [Creation] test.m line 8 column 3
                 // [TypeMerge:FileTypeMergingIntentionPass] Updated nullability signature from () -> String! to: () -> String
                 func aMethod() -> String {
                 }
@@ -182,7 +182,7 @@ class SwiftRewriter_IntentionPassHistoryTests: XCTestCase {
             swift: """
             // Preprocessor directives found in file:
             // #define CONSTANT 1
-            // [Creation] Converted from compiler directive #define CONSTANT 1
+            // [Creation] Converted from compiler directive from test.m line 1: #define CONSTANT 1
             private let CONSTANT: Int = 1
             """,
             options: SwiftSyntaxOptions.default.with(\.printIntentionHistory, true))

--- a/Tests/SwiftRewriterLibTests/SwiftRewriter+IntentionPassHistoryTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriter+IntentionPassHistoryTests.swift
@@ -173,4 +173,18 @@ class SwiftRewriter_IntentionPassHistoryTests: XCTestCase {
             .transpile(options: SwiftSyntaxOptions.default.with(\.printIntentionHistory, true))
             .assertExpectedSwiftFiles()
     }
+    
+    func testDefineDeclarationHistoryTracking() {
+        assertRewrite(
+            objc: """
+            #define CONSTANT 1
+            """,
+            swift: """
+            // Preprocessor directives found in file:
+            // #define CONSTANT 1
+            // [Creation] Converted from compiler directive #define CONSTANT 1
+            private let CONSTANT: Int = 1
+            """,
+            options: SwiftSyntaxOptions.default.with(\.printIntentionHistory, true))
+    }
 }

--- a/Tests/SwiftRewriterLibTests/SwiftRewriterTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriterTests.swift
@@ -3104,7 +3104,7 @@ class SwiftRewriterTests: XCTestCase {
             """)
     }
     
-    func testRewriteConstantFromMacro() {
+    func testRewriteConstantFromMacroInHeader() {
         assertRewrite(
             objc: """
             #define CONSTANT 1
@@ -3116,6 +3116,36 @@ class SwiftRewriterTests: XCTestCase {
             // #define CONSTANT2 1 + 1
             let CONSTANT: Int = 1
             let CONSTANT2: Int = 1 + 1
+            """,
+            inputFileName: "test.h")
+    }
+    
+    func testRewriteConstantFromMacroInImplementation() {
+        assertRewrite(
+            objc: """
+            #define CONSTANT 1
+            #define CONSTANT2 1 + 1
+            """,
+            swift: """
+            // Preprocessor directives found in file:
+            // #define CONSTANT 1
+            // #define CONSTANT2 1 + 1
+            private let CONSTANT: Int = 1
+            private let CONSTANT2: Int = 1 + 1
+            """,
+            inputFileName: "test.m")
+    }
+    
+    func testRewriteIgnoresInvalidConstantFromMacro() {
+        assertRewrite(
+            objc: """
+            #define CONSTANT (1
+            #define CONSTANT2 unknown + identifiers
+            """,
+            swift: """
+            // Preprocessor directives found in file:
+            // #define CONSTANT (1
+            // #define CONSTANT2 unknown + identifiers
             """)
     }
 }

--- a/Tests/SwiftRewriterLibTests/SwiftRewriterTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriterTests.swift
@@ -915,7 +915,7 @@ class SwiftRewriterTests: XCTestCase {
             #import <File.h>
             #if 0
             #endif
-            #define MACRO 123
+            #define MACRO(A) 123 * A
             """,
             swift: """
             import File
@@ -925,7 +925,7 @@ class SwiftRewriterTests: XCTestCase {
             // #import <File.h>
             // #if 0
             // #endif
-            // #define MACRO 123
+            // #define MACRO(A) 123 * A
             """)
     }
     

--- a/Tests/SwiftRewriterLibTests/SwiftRewriterTests.swift
+++ b/Tests/SwiftRewriterLibTests/SwiftRewriterTests.swift
@@ -3103,4 +3103,19 @@ class SwiftRewriterTests: XCTestCase {
             }
             """)
     }
+    
+    func testRewriteConstantFromMacro() {
+        assertRewrite(
+            objc: """
+            #define CONSTANT 1
+            #define CONSTANT2 1 + 1
+            """,
+            swift: """
+            // Preprocessor directives found in file:
+            // #define CONSTANT 1
+            // #define CONSTANT2 1 + 1
+            let CONSTANT: Int = 1
+            let CONSTANT2: Int = 1 + 1
+            """)
+    }
 }

--- a/Tests/SwiftSyntaxSupportTests/SwiftSyntaxProducerTests.swift
+++ b/Tests/SwiftSyntaxSupportTests/SwiftSyntaxProducerTests.swift
@@ -453,8 +453,8 @@ extension SwiftSyntaxProducerTests {
     func testGeneratePreprocessorDirectivesInEmptyFile() {
         let file = FileIntentionBuilder
             .makeFileIntention(fileName: "Test.swift") { builder in
-                builder.addPreprocessorDirective("#import <Abc.h>")
-                builder.addPreprocessorDirective("#define MAX(a, b) ((a) > (b) ? (a) : (b))")
+                builder.addPreprocessorDirective("#import <Abc.h>", line: 1)
+                builder.addPreprocessorDirective("#define MAX(a, b) ((a) > (b) ? (a) : (b))", line: 2)
             }
         let sut = SwiftSyntaxProducer()
         
@@ -470,8 +470,8 @@ extension SwiftSyntaxProducerTests {
     func testGeneratePreprocessorDirectivesInPopulatedFile() {
         let file = FileIntentionBuilder
             .makeFileIntention(fileName: "Test.swift") { builder in
-                builder.addPreprocessorDirective("#import <Abc.h>")
-                builder.addPreprocessorDirective("#define MAX(a, b) ((a) > (b) ? (a) : (b))")
+                builder.addPreprocessorDirective("#import <Abc.h>", line: 1)
+                builder.addPreprocessorDirective("#define MAX(a, b) ((a) > (b) ? (a) : (b))", line: 2)
                 builder.createClass(withName: "A")
             }
         let sut = SwiftSyntaxProducer()

--- a/Tests/TypeSystemTests/TypeSystemTests.swift
+++ b/Tests/TypeSystemTests/TypeSystemTests.swift
@@ -835,21 +835,21 @@ class TypeSystemTests: XCTestCase {
         XCTAssertEqual(sut.category(forType: "GLenum"), .integer)
     }
     
-    func testTypeExists() {
+    func testNominalTypeExists() {
         let type = KnownTypeBuilder(typeName: "A").build()
         sut.addType(type)
         
-        XCTAssert(sut.typeExists("A"))
-        XCTAssertFalse(sut.typeExists("Unknown"))
+        XCTAssert(sut.nominalTypeExists("A"))
+        XCTAssertFalse(sut.nominalTypeExists("Unknown"))
     }
     
-    func testTypeExistsQueriesTypeProviders() {
+    func testNominalTypeExistsQueriesTypeProviders() {
         let type = KnownTypeBuilder(typeName: "A").build()
         let provider = CollectionKnownTypeProvider(knownTypes: [type])
         sut.addKnownTypeProvider(provider)
         
-        XCTAssert(sut.typeExists("A"))
-        XCTAssertFalse(sut.typeExists("Unknown"))
+        XCTAssert(sut.nominalTypeExists("A"))
+        XCTAssertFalse(sut.nominalTypeExists("Unknown"))
     }
     
     func testExtensionTypesDontOvershadowOriginalImplementation() {


### PR DESCRIPTION
Converts `#define` preprocessor directives that define expressions into global constants, when appropriate.